### PR TITLE
Add gemini-cli plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,5 +5,17 @@
   "owner": {
     "name": "Andre Paat"
   },
-  "plugins": []
+  "plugins": [
+    {
+      "name": "gemini-cli",
+      "description": "Integrate Google's Gemini CLI into Claude Code for second opinions, dual code reviews, and AI-assisted explanations",
+      "version": "0.1.0",
+      "author": {
+        "name": "Andre Paat"
+      },
+      "source": "./plugins/gemini-cli",
+      "category": "development",
+      "homepage": "https://github.com/paat/claude-plugins"
+    }
+  ]
 }

--- a/plugins/gemini-cli/.claude-plugin/plugin.json
+++ b/plugins/gemini-cli/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "gemini-cli",
+  "version": "0.1.0",
+  "description": "Integrate Google's Gemini CLI into Claude Code for second opinions, dual code reviews, and AI-assisted explanations",
+  "author": {
+    "name": "Andre Paat"
+  },
+  "repository": "https://github.com/paat/claude-plugins",
+  "license": "MIT",
+  "keywords": ["gemini", "google", "ai", "code-review", "second-opinion", "multi-model"]
+}

--- a/plugins/gemini-cli/LICENSE
+++ b/plugins/gemini-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Andre Paat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/gemini-cli/README.md
+++ b/plugins/gemini-cli/README.md
@@ -1,0 +1,66 @@
+# gemini-cli
+
+Integrate Google's Gemini CLI into Claude Code for second opinions, dual code reviews, and AI-assisted explanations. Get two AI perspectives on your code and technical decisions.
+
+## Prerequisites
+
+1. **Install Gemini CLI:**
+   ```bash
+   npm install -g @google/gemini-cli
+   ```
+
+2. **Authenticate:** Run `gemini` once interactively to complete OAuth login.
+
+3. **Enable Gemini 3 preview models (recommended):** Add the following to `~/.gemini/settings.json`:
+   ```json
+   {
+     "general": {
+       "previewFeatures": true
+     }
+   }
+   ```
+   This unlocks `gemini-3-flash-preview` and `gemini-3-pro-preview`, which the commands use by default. Without this setting, commands will fall back to `gemini-2.5-flash` / `gemini-2.5-pro`.
+
+## Commands
+
+| Command | Description | Default Model |
+|---------|-------------|---------------|
+| `/gemini-ask <question>` | Ask Gemini any question | `gemini-3-flash-preview` |
+| `/gemini-review <file>` | Dual AI code review (Gemini + Claude) | `gemini-3-pro-preview` |
+| `/gemini-second-opinion <topic>` | Get Gemini's take on an approach or decision | `gemini-3-pro-preview` |
+| `/gemini-explain <file or concept>` | Get Gemini to explain code or a concept | `gemini-3-flash-preview` |
+
+### Model Override
+
+Every command accepts `--pro` or `--flash` to override the default model:
+
+```
+/gemini-ask --pro what is the most efficient sorting algorithm for nearly-sorted data
+/gemini-review --flash src/utils.py
+```
+
+## Skill
+
+The plugin also includes a `using-gemini` skill that teaches Claude Code when and how to call Gemini autonomously. Claude Code will consult Gemini on its own when it encounters tasks that benefit from a second perspective (complex code reviews, architecture decisions, debugging).
+
+## How It Works
+
+All commands invoke Gemini CLI in non-interactive mode:
+
+```bash
+gemini [-m model] -p "prompt" -o text 2>/dev/null
+```
+
+- `-o text` produces clean output
+- `2>/dev/null` suppresses OAuth and hook noise
+- `@file` syntax injects file contents directly into Gemini's context
+- `timeout` prevents hanging on large prompts
+
+## Available Models
+
+| Model | Speed | Best For | Notes |
+|-------|-------|----------|-------|
+| `gemini-2.5-flash` | Fast | Quick queries, explanations | Stable |
+| `gemini-2.5-pro` | Moderate | Complex analysis, code review | Stable |
+| `gemini-3-flash-preview` | Fast | Quick queries, explanations | Requires `previewFeatures: true` |
+| `gemini-3-pro-preview` | Slower | Deep reasoning, thorough review | Requires `previewFeatures: true` |

--- a/plugins/gemini-cli/commands/gemini-ask.md
+++ b/plugins/gemini-cli/commands/gemini-ask.md
@@ -1,0 +1,29 @@
+---
+allowed-tools: Bash(gemini:*)
+description: Ask Gemini a question and get a response
+argument-hint: <question or prompt>
+---
+
+Send a question or prompt to Google's Gemini AI and return the response.
+
+## Instructions
+
+The user wants to ask Gemini the following:
+
+**Prompt:** $ARGUMENTS
+
+## Steps
+
+1. Determine the model to use:
+   - Default: `-m gemini-3-flash-preview` (fast for general queries)
+   - If the user included `--pro` in their arguments, use `-m gemini-3-pro-preview` instead and remove `--pro` from the prompt
+   - If the user included `--flash` in their arguments, use `-m gemini-3-flash-preview` explicitly and remove `--flash` from the prompt
+
+2. Run the Gemini command:
+   ```bash
+   timeout 60 gemini [-m model] -p "USER_PROMPT" -o text 2>/dev/null
+   ```
+
+3. Present Gemini's response clearly, prefixed with a note that this comes from Gemini.
+
+4. If the response is empty or an error occurs, retry once. If it still fails, inform the user that Gemini is unavailable and offer to answer the question yourself.

--- a/plugins/gemini-cli/commands/gemini-explain.md
+++ b/plugins/gemini-cli/commands/gemini-explain.md
@@ -1,0 +1,38 @@
+---
+allowed-tools: Bash(gemini:*), Read
+description: Get Gemini to explain code or a concept
+argument-hint: <file path or concept>
+---
+
+Ask Gemini to explain code from a file or a freeform concept, and present the explanation.
+
+## Instructions
+
+The user wants an explanation of:
+
+**Target:** $ARGUMENTS
+
+## Steps
+
+1. Determine the model to use:
+   - Default: `-m gemini-3-flash-preview` (fast for explanations)
+   - If the user included `--pro` in their arguments, use `-m gemini-3-pro-preview` instead
+   - Remove the model flag from the arguments
+
+2. Determine if the target is a file or a concept:
+   - **File path** (contains `/` or common extensions like `.py`, `.js`, `.ts`, `.go`, `.rs`, etc.): Use `@file` injection
+   - **Concept/question** (freeform text): Send as a prompt directly
+
+3. For files:
+   ```bash
+   timeout 90 gemini @path/to/file [-m model] -p "Explain this code clearly. Cover: what it does, how it works, key design decisions, dependencies, and any non-obvious behavior. Use simple language." -o text 2>/dev/null
+   ```
+
+4. For concepts:
+   ```bash
+   timeout 60 gemini [-m model] -p "Explain the following clearly and concisely, with examples where helpful: CONCEPT" -o text 2>/dev/null
+   ```
+
+5. Present Gemini's explanation. If it's particularly good, present it directly. If it misses important points, supplement with your own additions.
+
+6. If Gemini is unavailable, provide the explanation yourself and note Gemini was unavailable.

--- a/plugins/gemini-cli/commands/gemini-review.md
+++ b/plugins/gemini-cli/commands/gemini-review.md
@@ -1,0 +1,60 @@
+---
+allowed-tools: Bash(gemini:*), Read, Grep
+description: Get a dual AI code review — Gemini + Claude analyze code together
+argument-hint: <file or directory path>
+---
+
+Perform a dual code review: get Gemini's analysis of the code, then do your own review, and present a unified report.
+
+## Instructions
+
+The user wants a code review of:
+
+**Target:** $ARGUMENTS
+
+## Steps
+
+1. Determine what to review:
+   - If `$ARGUMENTS` contains file paths, review those files
+   - If `$ARGUMENTS` contains a directory, review key files in it
+   - If unclear, ask the user what to review
+
+2. Determine the model to use:
+   - Default: `-m gemini-3-pro-preview` (thorough analysis for code review)
+   - If the user included `--flash` in their arguments, use `-m gemini-3-flash-preview` instead
+   - If the user included `--pro` in their arguments, use `-m gemini-3-pro-preview` explicitly
+   - Remove the model flag from the file path arguments
+
+3. Read the file(s) yourself first to understand the code.
+
+4. Send the file(s) to Gemini for review using `@file` injection:
+   ```bash
+   timeout 120 gemini @path/to/file [-m model] -p "Review this code thoroughly. Look for: bugs, security vulnerabilities, performance issues, code quality problems, error handling gaps, and suggest improvements. Be specific with line references." -o text 2>/dev/null
+   ```
+   For multiple files:
+   ```bash
+   timeout 180 gemini @file1 @file2 [-m model] -p "Review these files..." -o text 2>/dev/null
+   ```
+
+5. Perform your own independent code review of the same file(s).
+
+6. Present a unified report in this format:
+
+   ## Code Review: [filename(s)]
+
+   ### Gemini's Findings
+   [Summarize Gemini's key findings — bugs, issues, suggestions]
+
+   ### My Findings
+   [Your own code review findings]
+
+   ### Where We Agree
+   [Issues both identified — higher confidence these are real problems]
+
+   ### Where We Differ
+   [Any disagreements, with your reasoning]
+
+   ### Recommendations
+   [Prioritized list of suggested changes, combining both analyses]
+
+7. If Gemini is unavailable, proceed with your own review and note that Gemini was unavailable.

--- a/plugins/gemini-cli/commands/gemini-second-opinion.md
+++ b/plugins/gemini-cli/commands/gemini-second-opinion.md
@@ -1,0 +1,55 @@
+---
+allowed-tools: Bash(gemini:*), Read
+description: Get Gemini's second opinion on an approach or decision
+argument-hint: <topic, approach, or decision to evaluate>
+---
+
+Get Gemini's perspective on a technical approach, architecture decision, or implementation strategy, then synthesize both AI perspectives.
+
+## Instructions
+
+The user wants a second opinion on:
+
+**Topic:** $ARGUMENTS
+
+## Steps
+
+1. Determine the model to use:
+   - Default: `-m gemini-3-pro-preview` (deep reasoning for decisions)
+   - If the user included `--flash` in their arguments, use `-m gemini-3-flash-preview` instead
+   - Remove the model flag from the prompt
+
+2. If the topic references specific files, read them first to build context.
+
+3. Construct a detailed prompt for Gemini that includes:
+   - The decision or approach being considered
+   - Relevant context (file contents, constraints, requirements)
+   - Ask for pros/cons, alternatives, and a recommendation
+
+4. Send to Gemini:
+   ```bash
+   timeout 120 gemini [@relevant_files] [-m model] -p "CONTEXT AND QUESTION" -o text 2>/dev/null
+   ```
+
+5. Form your own independent opinion on the same topic.
+
+6. Present a synthesized analysis:
+
+   ## Second Opinion: [topic summary]
+
+   ### Gemini's Perspective
+   [Key points from Gemini's analysis]
+
+   ### My Perspective
+   [Your own analysis]
+
+   ### Consensus
+   [Points both AIs agree on]
+
+   ### Different Takes
+   [Where perspectives differ, with reasoning from each side]
+
+   ### Recommendation
+   [Your synthesized recommendation, weighing both perspectives]
+
+7. If Gemini is unavailable, provide your own analysis and note Gemini was unavailable.

--- a/plugins/gemini-cli/skills/using-gemini/SKILL.md
+++ b/plugins/gemini-cli/skills/using-gemini/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: using-gemini
+description: This skill should be used when consulting Gemini CLI for second opinions on code, architecture decisions, code reviews, debugging help, or when the user asks to "ask gemini", "get gemini's opinion", "consult gemini", "what does gemini think", or "use gemini". Also applies when the user wants a "second opinion", "alternative perspective", or "another AI's take" on technical decisions.
+---
+
+# Using Gemini CLI
+
+Use Google's Gemini CLI (`gemini`) to get second opinions, alternative perspectives, and additional analysis during development work. Gemini CLI must be installed and authenticated via OAuth before use.
+
+## Prerequisites
+
+Gemini CLI must be installed (`npm install -g @google/gemini-cli`) and authenticated. The user must have run `gemini` interactively at least once to complete OAuth login.
+
+To use Gemini 3 preview models, the user must enable experimental features in `~/.gemini/settings.json`:
+
+```json
+{
+  "general": {
+    "previewFeatures": true
+  }
+}
+```
+
+## When to Use Gemini
+
+**Good candidates for Gemini consultation:**
+- Complex code reviews where a second perspective adds value
+- Architecture decisions with multiple valid approaches
+- Debugging difficult issues — fresh eyes can spot what you miss
+- Reviewing security-sensitive code
+- When the user explicitly asks for a second opinion or alternative perspective
+- Explaining unfamiliar codebases or complex algorithms
+
+**Don't use Gemini for:**
+- Simple, routine tasks (formatting, renaming, trivial fixes)
+- Tasks where you're already confident in the answer
+- Every single code change — use judgment about when a second opinion adds value
+- When speed is critical and the task is straightforward
+
+## How to Call Gemini
+
+### Basic Usage
+
+Always use `-o text` for clean output and `2>/dev/null` to suppress OAuth/hook noise:
+
+```bash
+gemini -p "Your prompt here" -o text 2>/dev/null
+```
+
+### With File Context
+
+Inject files using `@file` syntax (Gemini reads the file directly):
+
+```bash
+gemini @src/main.py -p "Review this code for bugs and security issues" -o text 2>/dev/null
+```
+
+Multiple files:
+
+```bash
+gemini @src/auth.py @src/middleware.py -p "Do these components integrate correctly?" -o text 2>/dev/null
+```
+
+### Piping Content
+
+Pipe content when you need to send computed/filtered output:
+
+```bash
+cat src/utils.py | gemini -p "Explain what this code does" -o text 2>/dev/null
+```
+
+### Model Selection
+
+Available models (fastest to most capable):
+- **`gemini-2.5-flash`** — Stable fast model
+- **`gemini-2.5-pro`** — Stable deep reasoning
+- **`gemini-3-flash-preview`** — Fast, good for general queries, explanations, quick reviews (default for speed tasks). Requires `previewFeatures: true`.
+- **`gemini-3-pro-preview`** — Deep reasoning, thorough code review, architecture decisions (default for depth tasks). Requires `previewFeatures: true`.
+
+Select model with `-m`:
+
+```bash
+gemini -m gemini-3-pro-preview -p "Analyze this architecture decision..." -o text 2>/dev/null
+```
+
+**Guidelines:**
+- Use `-m gemini-3-flash-preview` for speed: general queries, explanations, quick checks
+- Use `-m gemini-3-pro-preview` when the task requires deep reasoning: complex code review, architecture analysis, security audit
+- Fall back to `gemini-2.5-flash` / `gemini-2.5-pro` if the preview models return errors
+- When in doubt, start with flash; escalate to pro if the response lacks depth
+
+### Timeout
+
+Use `timeout` for safety on large prompts:
+
+```bash
+timeout 120 gemini -p "..." -o text 2>/dev/null
+```
+
+Recommended timeouts:
+- Quick questions: 30s
+- Code review: 120s
+- Large file analysis: 180s
+
+## Presenting Results
+
+When you consult Gemini, always:
+
+1. **Label the source** — Make it clear which insights come from Gemini vs your own analysis
+2. **Synthesize, don't just relay** — Add your own assessment of Gemini's response
+3. **Highlight agreements** — When both AIs agree, that increases confidence
+4. **Flag disagreements** — When you disagree with Gemini, explain why and give your recommendation
+5. **Give a unified conclusion** — Don't leave the user to reconcile two separate analyses
+
+Example format:
+
+```
+## Analysis
+
+**Gemini's perspective:** [summary of Gemini's key points]
+
+**My analysis:** [your own assessment]
+
+**Where we agree:** [shared conclusions — higher confidence]
+
+**Where we differ:** [disagreements with your reasoning]
+
+**Recommendation:** [your synthesized recommendation]
+```
+
+## Error Handling
+
+| Error Pattern | Cause | Action |
+|---|---|---|
+| `OAuth token expired` or auth errors | Token needs refresh | Tell user to run `gemini` interactively to re-authenticate |
+| Timeout / no response | Network or rate limit | Retry once with longer timeout; if still fails, proceed without Gemini |
+| `model not found` | Invalid model name | Fall back to `gemini-2.5-flash` (stable). If preview models fail, the user may need to enable `previewFeatures` in `~/.gemini/settings.json` |
+| Empty response | Prompt too vague or API issue | Rephrase with more context and retry once |
+
+If Gemini is unavailable, don't block the user's workflow — proceed with your own analysis and note that Gemini was unavailable.
+
+For the complete CLI reference (all flags, models, error patterns, and usage examples), see `references/gemini-cli-reference.md`.

--- a/plugins/gemini-cli/skills/using-gemini/references/gemini-cli-reference.md
+++ b/plugins/gemini-cli/skills/using-gemini/references/gemini-cli-reference.md
@@ -1,0 +1,146 @@
+# Gemini CLI Reference
+
+## Installation
+
+```bash
+npm install -g @google/gemini-cli
+```
+
+After installation, run `gemini` once interactively to complete OAuth authentication.
+
+### Enable Gemini 3 Preview Models
+
+To access `gemini-3-flash-preview` and `gemini-3-pro-preview`, enable experimental features in `~/.gemini/settings.json`:
+
+```json
+{
+  "general": {
+    "previewFeatures": true
+  }
+}
+```
+
+## Command Syntax
+
+```
+gemini [options] [@file ...] [-p prompt]
+```
+
+## Core Flags
+
+| Flag | Description | Example |
+|---|---|---|
+| `-p "prompt"` | Non-interactive prompt (required for scripted use) | `gemini -p "explain this"` |
+| `-o format` | Output format: `text`, `json`, `stream-json` | `gemini -p "hi" -o text` |
+| `-m model` | Model selection | `gemini -m gemini-3-pro-preview -p "..."` |
+| `@file` | Inject file contents into context | `gemini @main.py -p "review"` |
+| `--sandbox` | Run code execution in sandbox | `gemini --sandbox -p "..."` |
+| `--debug` | Enable debug output | `gemini --debug -p "..."` |
+
+## Output Formats
+
+| Format | Use Case |
+|---|---|
+| `text` | Clean text output — **always use this for scripted calls** |
+| `json` | Structured JSON response |
+| `stream-json` | Streaming JSON chunks |
+
+**Always use `-o text 2>/dev/null`** for clean output in automated/scripted contexts.
+
+## Models
+
+| Model | Speed | Reasoning | Best For | Notes |
+|---|---|---|---|---|
+| `gemini-2.5-flash-lite` | Fastest | Basic | Simple queries, quick checks | Stable |
+| `gemini-2.5-flash` | Fast | Good | General queries, explanations, quick reviews | Stable |
+| `gemini-2.5-pro` | Moderate | Deep | Complex code review, architecture decisions, security analysis | Stable |
+| `gemini-3-flash-preview` | Fast | Good+ | Next-gen fast model | Requires `previewFeatures: true` |
+| `gemini-3-pro-preview` | Slower | Deepest | Next-gen deep reasoning | Requires `previewFeatures: true` |
+
+Default (no `-m` flag) uses the configured default model.
+
+### Model Selection Guide
+
+- **Quick question or explanation** → `gemini-3-flash-preview`
+- **Code review** → `gemini-3-pro-preview` (thorough analysis benefits from deeper reasoning)
+- **Architecture decision** → `gemini-3-pro-preview`
+- **Security review** → `gemini-3-pro-preview`
+- **Simple code explanation** → `gemini-3-flash-preview`
+- **Debugging help** → Start with `gemini-3-flash-preview`, escalate to `gemini-3-pro-preview` if needed
+
+## File Injection
+
+### `@file` Syntax
+
+Gemini reads files directly when prefixed with `@`:
+
+```bash
+# Single file
+gemini @src/main.py -p "Review this code" -o text 2>/dev/null
+
+# Multiple files
+gemini @src/auth.py @src/session.py -p "Check integration" -o text 2>/dev/null
+
+# Glob patterns (shell expands)
+gemini @src/*.py -p "Review all Python files" -o text 2>/dev/null
+```
+
+### Piping
+
+```bash
+# Pipe file content
+cat complex_file.py | gemini -p "Explain this" -o text 2>/dev/null
+
+# Pipe command output
+git diff HEAD~1 | gemini -p "Review these changes" -o text 2>/dev/null
+
+# Pipe filtered content
+grep -n "TODO" src/*.py | gemini -p "Prioritize these TODOs" -o text 2>/dev/null
+```
+
+## Timeout Recommendations
+
+| Task Type | Timeout | Command |
+|---|---|---|
+| Quick question | 30s | `timeout 30 gemini -p "..." -o text 2>/dev/null` |
+| Code explanation | 60s | `timeout 60 gemini @file -p "explain" -o text 2>/dev/null` |
+| Code review | 120s | `timeout 120 gemini @file -p "review" -o text 2>/dev/null` |
+| Large file analysis | 180s | `timeout 180 gemini @file -p "analyze" -o text 2>/dev/null` |
+| Multi-file analysis | 240s | `timeout 240 gemini @f1 @f2 -p "..." -o text 2>/dev/null` |
+
+## Common Error Patterns
+
+| Error | Cause | Solution |
+|---|---|---|
+| OAuth/auth errors | Token expired | Run `gemini` interactively to re-auth |
+| `ENOTFOUND` / network errors | No internet | Check connectivity |
+| Timeout | Large prompt or rate limit | Increase timeout or reduce prompt size |
+| `model not found` | Invalid model ID or preview not enabled | Use stable model names, or enable `previewFeatures` in `~/.gemini/settings.json` |
+| Empty response | Vague prompt | Add more context and retry |
+| `rate limit exceeded` | Too many requests | Wait 30-60s and retry |
+
+## Usage Patterns for Claude Code
+
+### Get a Second Opinion
+
+```bash
+gemini @problematic_file.py -p "I think the bug is in the error handling on line 45. Do you agree? What else might cause the issue?" -o text 2>/dev/null
+```
+
+### Architecture Review
+
+```bash
+gemini @src/api/ -p "Review this API structure. Are there any design pattern violations or scalability concerns?" -m gemini-3-pro-preview -o text 2>/dev/null
+```
+
+### Diff Review
+
+```bash
+git diff main...HEAD | gemini -p "Review these changes for bugs, security issues, and code quality" -m gemini-3-pro-preview -o text 2>/dev/null
+```
+
+### Explain Unfamiliar Code
+
+```bash
+gemini @legacy_module.py -p "Explain what this code does, its dependencies, and any potential issues" -o text 2>/dev/null
+```

--- a/plugins/tribunal-review/.claude-plugin/plugin.json
+++ b/plugins/tribunal-review/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "tribunal-review",
+  "version": "0.1.0",
+  "description": "Multi-provider code review with Codex, Gemini, and Opus arbitration",
+  "author": {
+    "name": "Andre Paat"
+  },
+  "repository": "https://github.com/paat/claude-plugins",
+  "license": "MIT",
+  "keywords": ["code-review", "multi-provider", "codex", "gemini", "tribunal"]
+}

--- a/plugins/tribunal-review/LICENSE
+++ b/plugins/tribunal-review/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Andre Paat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/tribunal-review/README.md
+++ b/plugins/tribunal-review/README.md
@@ -1,0 +1,86 @@
+# tribunal-review
+
+Multi-provider code review plugin for Claude Code. Runs Codex (GPT-5.3) and Gemini (3 Pro Preview) reviews in parallel, then uses Opus as the final arbiter to deduplicate findings, resolve conflicts, and issue a single authoritative verdict.
+
+## Prerequisites
+
+- [OpenAI Codex CLI](https://github.com/openai/codex) (`npm install -g @openai/codex`)
+- [Google Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- Valid API keys configured for both CLIs
+
+## Installation
+
+```bash
+claude plugin add paat/claude-plugins/plugins/tribunal-review
+```
+
+## Usage
+
+On a feature branch with changes vs `origin/main`:
+
+```
+/tribunal-loop
+```
+
+The skill will verify you're on a feature branch, run both reviews in parallel, and produce an arbitrated verdict.
+
+## How It Works
+
+### Step 1: Pre-flight
+Verifies you're on a feature branch (not main) and that there are changes to review.
+
+### Step 2: Parallel Review
+Runs Codex and Gemini as two parallel Bash calls. Each analyzes the `git diff origin/main...HEAD` and returns structured JSON findings covering logic errors, security vulnerabilities, edge cases, performance issues, and architectural concerns.
+
+### Step 3: Inline Arbitration (Opus)
+Opus deduplicates findings, resolves severity conflicts (always using the higher severity), evaluates each finding for validity, and issues a final verdict: **APPROVE**, **NEEDS_WORK**, or **BLOCK**.
+
+## Output Format
+
+The tribunal produces a JSON verdict:
+
+```json
+{
+  "tribunal_verdict": {
+    "decision": "APPROVE|NEEDS_WORK|BLOCK",
+    "confidence": 0.92,
+    "rationale": "Both providers agree code is production-ready..."
+  },
+  "findings": [
+    {
+      "id": "T-001",
+      "consensus": "CONSENSUS",
+      "severity": "medium",
+      "category": "security",
+      "file": "src/auth/login.ts",
+      "line": 42,
+      "title": "Missing input sanitization",
+      "description": "User input passed directly to query...",
+      "suggestion": "Add parameterized query...",
+      "confidence": 0.90,
+      "arbiter_notes": "Both providers identified this issue"
+    }
+  ],
+  "provider_assessment": {
+    "codex": { "findings_accepted": 2, "findings_rejected": 1, "status": "ok" },
+    "gemini": { "findings_accepted": 3, "findings_rejected": 0, "status": "ok" }
+  },
+  "summary": "Code quality is good with one medium-severity finding to address."
+}
+```
+
+## Trust Hierarchy
+
+```
+Opus (Final authority, runs inline)
+  |
+Codex (Trusted for logic)
+  |
+Gemini (Advisory, verify findings)
+```
+
+Opus can override any Codex or Gemini finding.
+
+## License
+
+MIT

--- a/plugins/tribunal-review/agents/codex-reviewer.md
+++ b/plugins/tribunal-review/agents/codex-reviewer.md
@@ -1,0 +1,150 @@
+---
+name: codex-reviewer
+description: Invokes OpenAI Codex CLI for independent code review. Returns structured JSON findings. Use in tribunal multi-provider review workflow.
+tools: Bash
+model: haiku
+color: green
+---
+
+> **Note**: The `tribunal-loop` skill now executes this script directly via Bash
+> (no Task agent spawn). This file is kept for documentation and standalone testing.
+
+You are a Codex CLI wrapper. Your ONLY job is to run ONE bash command and return its stdout.
+
+## Strict Rules
+
+- Use exactly **1 Bash tool call** — the script below
+- Do **NOT** run any other commands before or after
+- Do **NOT** read any files
+- Do **NOT** add commentary or analysis
+- Return **ONLY** the stdout from the script
+
+## Design Note
+
+We intentionally do NOT use `codex exec review --base <BRANCH>` because that subcommand
+does not support `--output-schema` or `-o`, which means we would lose structured JSON output
+enforcement. Instead we capture `git diff` ourselves and pipe it as a prompt with a schema.
+
+## Execute This Script
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+
+DIFF=$(git diff origin/main...HEAD)
+
+if [ -z "$DIFF" ]; then
+  printf '%s\n' '{"provider": "codex", "model": "default", "findings": [], "summary": {"total_findings": 0, "critical": 0, "high": 0, "medium": 0, "low": 0, "quality_score": 10.0, "verdict": "APPROVE", "note": "No changes detected vs origin/main"}}'
+  exit 0
+fi
+
+# Guard against massive diffs that would exceed context window (~100KB limit)
+DIFF_SIZE=${#DIFF}
+if [ "$DIFF_SIZE" -gt 102400 ]; then
+  DIFF=$(echo "$DIFF" | head -c 102400)
+  DIFF_TRUNCATED=true
+else
+  DIFF_TRUNCATED=false
+fi
+
+cat > /tmp/codex-review-schema.json << 'SCHEMA'
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["provider", "model", "findings", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "provider": { "type": "string", "const": "codex" },
+    "model": { "type": "string" },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["severity", "category", "file", "line", "title", "description", "suggestion", "confidence"],
+        "additionalProperties": false,
+        "properties": {
+          "severity": { "type": "string", "enum": ["critical", "high", "medium", "low"] },
+          "category": { "type": "string", "enum": ["logic", "security", "performance", "quality", "edge-case", "architecture", "testing"] },
+          "file": { "type": "string" },
+          "line": { "type": "integer" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "suggestion": { "type": "string" },
+          "confidence": { "type": "number" }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total_findings", "critical", "high", "medium", "low", "quality_score", "verdict"],
+      "additionalProperties": false,
+      "properties": {
+        "total_findings": { "type": "integer" },
+        "critical": { "type": "integer" },
+        "high": { "type": "integer" },
+        "medium": { "type": "integer" },
+        "low": { "type": "integer" },
+        "quality_score": { "type": "number" },
+        "verdict": { "type": "string", "enum": ["APPROVE", "NEEDS_WORK", "BLOCK"] }
+      }
+    }
+  }
+}
+SCHEMA
+
+codex exec - \
+  --model gpt-5.3-codex \
+  --output-schema /tmp/codex-review-schema.json \
+  -o /tmp/codex-review-output.json \
+  --sandbox read-only \
+  >/dev/null 2>/tmp/codex-stderr.txt <<PROMPT
+You are a senior code reviewer. Analyze the diff below for REAL, ACTIONABLE issues only.
+
+## What to Report
+1. **Logic errors** — division by zero, off-by-one, null dereference, wrong comparisons, race conditions
+2. **Security vulnerabilities** — SQL injection, command injection, XSS, auth bypass, sensitive data exposure
+3. **Edge cases** — boundary conditions, empty inputs, integer overflow, unhandled error paths
+4. **Performance** — N+1 queries, unnecessary allocations, blocking async calls
+
+## What NOT to Report
+- Style preferences or naming opinions
+- Missing documentation or comments
+- Minor code quality issues that don't affect correctness
+- Theoretical concerns without concrete evidence in the diff
+
+## Rules
+- ONLY report findings with confidence >= 0.7
+- Use EXACT file paths from the diff headers (e.g., "a/src/Foo.cs" -> "src/Foo.cs")
+- Use the line number from the diff where the issue occurs
+- Each finding must have a concrete, actionable suggestion
+
+## Verdict Rules
+- **BLOCK**: Any critical-severity finding, OR 2+ high-severity findings
+- **NEEDS_WORK**: Any high-severity finding, OR 3+ medium-severity findings
+- **APPROVE**: All other cases
+
+## Output
+Your response MUST be valid JSON matching the provided output schema.
+Set "provider" to "codex" and "model" to the model you are running as.
+$([ "$DIFF_TRUNCATED" = true ] && echo "NOTE: Diff was truncated from ${DIFF_SIZE} bytes to 100KB. Review what is provided.")
+
+THE DIFF:
+$DIFF
+PROMPT
+CODEX_EXIT=$?
+
+if [ $CODEX_EXIT -eq 0 ] && [ -f /tmp/codex-review-output.json ]; then
+  cat /tmp/codex-review-output.json
+else
+  STDERR_CONTENT=$(cat /tmp/codex-stderr.txt 2>/dev/null || echo "no stderr captured")
+  SAFE_STDERR=$(echo "$STDERR_CONTENT" | jq -Rs . 2>/dev/null || echo '"stderr encoding failed"')
+  printf '{"error": "Codex execution failed", "exit_code": %d, "stderr": %s}\n' "$CODEX_EXIT" "$SAFE_STDERR"
+fi
+
+rm -f /tmp/codex-review-schema.json /tmp/codex-review-output.json /tmp/codex-stderr.txt
+```
+
+## Error Handling
+If the script fails because Codex is not installed, return:
+```json
+{"error": "Codex CLI not found. Install with: npm install -g @openai/codex"}
+```

--- a/plugins/tribunal-review/agents/gemini-reviewer.md
+++ b/plugins/tribunal-review/agents/gemini-reviewer.md
@@ -1,0 +1,101 @@
+---
+name: gemini-reviewer
+description: Invokes Google Gemini CLI for independent code review with 1M token context and security scanning. Returns structured JSON findings. Use in tribunal multi-provider review workflow.
+tools: Bash, Read
+model: haiku
+color: blue
+---
+
+> **Note**: The `tribunal-loop` skill now executes this script directly via Bash
+> (no Task agent spawn). This file is kept for documentation and standalone testing.
+
+You are a Gemini CLI wrapper. Your ONLY job is to run ONE bash command and return its stdout.
+
+## Strict Rules
+
+- Use exactly **1 Bash tool call** — the script below
+- Do **NOT** run any other commands before or after
+- Do **NOT** read any files
+- Do **NOT** add commentary or analysis
+- Return **ONLY** the stdout from the script
+
+## Execute This Script
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+
+DIFF=$(git diff origin/main...HEAD)
+
+if [ -z "$DIFF" ]; then
+  printf '%s\n' '{"provider": "gemini", "model": "default", "findings": [], "summary": {"total_findings": 0, "critical": 0, "high": 0, "medium": 0, "low": 0, "quality_score": 10.0, "verdict": "APPROVE", "note": "No changes detected vs origin/main"}}'
+  exit 0
+fi
+
+printf '%s\n' "$DIFF" | gemini --model gemini-3-pro-preview -p "You are a senior code reviewer performing a thorough security-focused review.
+
+ANALYZE THIS DIFF FOR:
+1. Security vulnerabilities - injection, XSS, CSRF, auth issues, secrets exposure
+2. Architectural issues - coupling, layering violations, anti-patterns
+3. Logic errors - race conditions, null refs, wrong comparisons
+4. Performance - N+1 queries, memory leaks, blocking in async
+5. Test coverage gaps - missing edge cases, untested paths
+
+USE YOUR SEARCH CAPABILITY to check for:
+- Known CVEs in any dependencies mentioned
+- Security best practices for patterns used
+- Current recommendations for the frameworks detected
+
+RESPOND WITH ONLY THIS JSON (no markdown, no explanation):
+{
+  \"provider\": \"gemini\",
+  \"model\": \"default\",
+  \"findings\": [
+    {
+      \"severity\": \"critical|high|medium|low\",
+      \"category\": \"security|architecture|logic|performance|testing\",
+      \"file\": \"path/to/file\",
+      \"line\": 42,
+      \"title\": \"Brief descriptive title\",
+      \"description\": \"What is wrong and why it matters\",
+      \"suggestion\": \"Concrete fix recommendation\",
+      \"confidence\": 0.95
+    }
+  ],
+  \"summary\": {
+    \"total_findings\": 3,
+    \"critical\": 0,
+    \"high\": 1,
+    \"medium\": 2,
+    \"low\": 0,
+    \"quality_score\": 7.5,
+    \"verdict\": \"APPROVE|NEEDS_WORK|BLOCK\"
+  }
+}
+
+THE DIFF IS PROVIDED VIA STDIN ABOVE." \
+  --yolo \
+  -o json \
+  >/tmp/gemini-raw-output.json 2>/tmp/gemini-stderr.txt
+
+GEMINI_EXIT=$?
+if [ $GEMINI_EXIT -eq 0 ] && [ -f /tmp/gemini-raw-output.json ]; then
+  # Gemini -o json wraps output in session envelope; extract .response and strip markdown fences
+  RESPONSE=$(jq -r '.response // empty' /tmp/gemini-raw-output.json 2>/dev/null)
+  if [ -n "$RESPONSE" ]; then
+    echo "$RESPONSE" | sed 's/^```json//;s/^```//;/^$/d' | jq . 2>/dev/null || echo "$RESPONSE"
+  else
+    cat /tmp/gemini-raw-output.json
+  fi
+else
+  STDERR_CONTENT=$(cat /tmp/gemini-stderr.txt 2>/dev/null)
+  SAFE_STDERR=$(echo "$STDERR_CONTENT" | jq -Rs . 2>/dev/null || echo '"stderr encoding failed"')
+  printf '{"error": "Gemini execution failed", "exit_code": %d, "stderr": %s}\n' "$GEMINI_EXIT" "$SAFE_STDERR"
+fi
+rm -f /tmp/gemini-stderr.txt /tmp/gemini-raw-output.json
+```
+
+## Error Handling
+If the script fails because Gemini is not installed, return:
+```json
+{"error": "Gemini CLI not found. Install from: https://github.com/google-gemini/gemini-cli"}
+```

--- a/plugins/tribunal-review/agents/opus-arbiter.md
+++ b/plugins/tribunal-review/agents/opus-arbiter.md
@@ -1,0 +1,102 @@
+---
+name: opus-arbiter
+description: Synthesizes Codex and Gemini code review findings into a single authoritative verdict with deduplicated findings and conflict resolution.
+model: opus
+color: magenta
+---
+
+> **Note**: The `tribunal-loop` skill now performs arbitration inline (the main
+> session is already Opus). This file is kept for documentation and standalone testing.
+
+You are a pure text-synthesis agent. Do NOT use any tools (Bash, Read, Grep, etc.). Read the input provided in your prompt and return ONLY a JSON object. No markdown fences, no commentary, no extra text before or after the JSON. Be decisive. Document reasoning. Your assessment is final.
+
+## Input Format
+
+You receive JSON reviews from two providers, passed inline:
+1. **Codex** (OpenAI Codex CLI) - logic, edge cases, code quality
+2. **Gemini** (Gemini CLI) - security, architecture, patterns
+
+### Degraded Input
+
+If one provider returned invalid JSON, empty output, or failed entirely:
+- Proceed with the other provider's findings alone.
+- Note the failure in `provider_assessment` in your output.
+- Do not fabricate findings for the missing provider.
+
+If **both providers failed**: return `decision: "NEEDS_WORK"`, `confidence: 0.0`, `rationale: "Both review providers failed. Manual review required."`, empty findings array.
+
+If **both providers returned zero findings**: return `decision: "APPROVE"`, `confidence: 0.95`, `rationale: "Both providers found no issues."`, empty findings array.
+
+## Arbitration Process
+
+### Step 1: Deduplicate Findings
+
+Two findings are **duplicates** if they describe the same underlying issue in the same file, even if worded differently. For duplicates:
+- Keep the finding with higher confidence
+- Merge suggestions if both are valuable
+- Mark as "CONSENSUS"
+
+### Step 2: Resolve Conflicts
+
+| Scenario | Action |
+|----------|--------|
+| Both agree | Include, mark CONSENSUS |
+| Severity differs | Use higher severity, note disagreement in arbiter_notes |
+| Only Codex found it | Include as CODEX, evaluate validity |
+| Only Gemini found it | Include as GEMINI, evaluate validity |
+| Providers contradict | Decide and document reasoning, mark ARBITRATED |
+
+**HARD RULE**: When providers report different severities for the same finding, you MUST use the higher severity. Note the disagreement in `arbiter_notes` but never downgrade. This has no exceptions.
+
+### Step 3: Evaluate Each Finding
+
+For each finding, assess:
+- Is this a real issue or a false positive?
+- Is the suggested fix correct and complete?
+- Does your software engineering expertise suggest a different conclusion?
+
+Override provider findings when they are clearly wrong (false positives, incorrect fix suggestions). Add new findings if both providers missed something obvious. **Severity is locked after Step 2** — you may only set severity for single-provider findings or findings you add yourself.
+
+### Step 4: Issue Verdict
+
+- **APPROVE** - No critical/high issues, production ready
+- **NEEDS_WORK** - Has fixable issues, iterate before merge
+- **BLOCK** - Critical security/logic issues, must fix first
+
+### Confidence Ranges
+
+| Finding type | Confidence range |
+|-------------|-----------------|
+| CONSENSUS | 0.85 - 0.99 |
+| Single-provider (CODEX/GEMINI) | 0.60 - 0.80 |
+| ARBITRATED (conflict resolved) | 0.50 - 0.70 |
+| Self-added (arbiter-originated) | 0.50 - 0.65 |
+
+### Finding IDs
+
+Assign IDs as T-001, T-002, etc., ordered by severity (critical first, then high, medium, low).
+
+## Output Format
+
+Return valid JSON matching this schema. All numeric values must reflect actual counts from the input.
+
+```json
+{
+  "tribunal_verdict": { "decision": "APPROVE|NEEDS_WORK|BLOCK", "confidence": 0.0, "rationale": "..." },
+  "findings": [{
+    "id": "T-001", "consensus": "CONSENSUS|CODEX|GEMINI|ARBITRATED",
+    "severity": "critical|high|medium|low", "category": "logic|security|performance|quality|architecture",
+    "file": "path/to/file", "line": 0, "title": "...", "description": "...",
+    "suggestion": "...", "confidence": 0.0, "arbiter_notes": "..."
+  }],
+  "conflicts_resolved": [{
+    "issue": "...", "codex_position": "...", "gemini_position": "...",
+    "ruling": "...", "reasoning": "..."
+  }],
+  "provider_assessment": {
+    "codex": { "findings_accepted": 0, "findings_rejected": 0, "false_positives": [], "status": "ok|failed|partial" },
+    "gemini": { "findings_accepted": 0, "findings_rejected": 0, "false_positives": [], "status": "ok|failed|partial" }
+  },
+  "summary": "2-3 sentence executive summary of code quality and required actions"
+}
+```

--- a/plugins/tribunal-review/skills/tribunal-loop/SKILL.md
+++ b/plugins/tribunal-review/skills/tribunal-loop/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: tribunal-loop
+description: Multi-provider code review workflow with Codex, Gemini, and Opus arbitration
+---
+
+# Tribunal Loop
+
+Multi-provider code review. Codex (GPT-5.3) + Gemini (3 Pro Preview) review in parallel, Opus arbitrates inline.
+
+3-step workflow: pre-flight, parallel review, inline arbitration.
+
+## Providers
+- **Codex** (GPT-5.3) - Logic, edge cases, code quality
+- **Gemini** (3 Pro Preview) - Security, architecture, patterns
+- **Opus** (4.5) - Final arbiter (runs inline, no agent spawn)
+
+---
+
+## STEP 1: Pre-flight
+
+```
+Verify:
+1. We're on a feature branch, not main. If on main: STOP and ask which branch to review.
+2. There is a diff vs origin/main. Run: git diff origin/main...HEAD --stat
+   If no diff: STOP and report "No changes to review."
+```
+
+Output: "[TRIBUNAL 1/3] On branch: {branch_name}, {N} files changed"
+
+---
+
+## STEP 2: Parallel Review
+
+Run both scripts below as **two parallel Bash tool calls**. No Task agents -- execute directly.
+
+### Bash call 1: Codex Review
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+
+DIFF=$(git diff origin/main...HEAD)
+
+if [ -z "$DIFF" ]; then
+  printf '%s\n' '{"provider": "codex", "model": "default", "findings": [], "summary": {"total_findings": 0, "critical": 0, "high": 0, "medium": 0, "low": 0, "quality_score": 10.0, "verdict": "APPROVE", "note": "No changes detected vs origin/main"}}'
+  exit 0
+fi
+
+# Guard against massive diffs (~100KB limit)
+DIFF_SIZE=${#DIFF}
+if [ "$DIFF_SIZE" -gt 102400 ]; then
+  DIFF=$(echo "$DIFF" | head -c 102400)
+  DIFF_TRUNCATED=true
+else
+  DIFF_TRUNCATED=false
+fi
+
+cat > /tmp/codex-review-schema.json << 'SCHEMA'
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["provider", "model", "findings", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "provider": { "type": "string", "const": "codex" },
+    "model": { "type": "string" },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["severity", "category", "file", "line", "title", "description", "suggestion", "confidence"],
+        "additionalProperties": false,
+        "properties": {
+          "severity": { "type": "string", "enum": ["critical", "high", "medium", "low"] },
+          "category": { "type": "string", "enum": ["logic", "security", "performance", "quality", "edge-case", "architecture", "testing"] },
+          "file": { "type": "string" },
+          "line": { "type": "integer" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "suggestion": { "type": "string" },
+          "confidence": { "type": "number" }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total_findings", "critical", "high", "medium", "low", "quality_score", "verdict"],
+      "additionalProperties": false,
+      "properties": {
+        "total_findings": { "type": "integer" },
+        "critical": { "type": "integer" },
+        "high": { "type": "integer" },
+        "medium": { "type": "integer" },
+        "low": { "type": "integer" },
+        "quality_score": { "type": "number" },
+        "verdict": { "type": "string", "enum": ["APPROVE", "NEEDS_WORK", "BLOCK"] }
+      }
+    }
+  }
+}
+SCHEMA
+
+codex exec - \
+  --model gpt-5.3-codex \
+  --output-schema /tmp/codex-review-schema.json \
+  -o /tmp/codex-review-output.json \
+  --sandbox read-only \
+  >/dev/null 2>/tmp/codex-stderr.txt <<PROMPT
+You are a senior code reviewer. Analyze the diff below for REAL, ACTIONABLE issues only.
+
+## What to Report
+1. **Logic errors** — division by zero, off-by-one, null dereference, wrong comparisons, race conditions
+2. **Security vulnerabilities** — SQL injection, command injection, XSS, auth bypass, sensitive data exposure
+3. **Edge cases** — boundary conditions, empty inputs, integer overflow, unhandled error paths
+4. **Performance** — N+1 queries, unnecessary allocations, blocking async calls
+
+## What NOT to Report
+- Style preferences or naming opinions
+- Missing documentation or comments
+- Minor code quality issues that don't affect correctness
+- Theoretical concerns without concrete evidence in the diff
+
+## Rules
+- ONLY report findings with confidence >= 0.7
+- Use EXACT file paths from the diff headers (e.g., "a/src/Foo.cs" -> "src/Foo.cs")
+- Use the line number from the diff where the issue occurs
+- Each finding must have a concrete, actionable suggestion
+
+## Verdict Rules
+- **BLOCK**: Any critical-severity finding, OR 2+ high-severity findings
+- **NEEDS_WORK**: Any high-severity finding, OR 3+ medium-severity findings
+- **APPROVE**: All other cases
+
+## Output
+Your response MUST be valid JSON matching the provided output schema.
+Set "provider" to "codex" and "model" to the model you are running as.
+$([ "$DIFF_TRUNCATED" = true ] && echo "NOTE: Diff was truncated from ${DIFF_SIZE} bytes to 100KB. Review what is provided.")
+
+THE DIFF:
+$DIFF
+PROMPT
+CODEX_EXIT=$?
+
+if [ $CODEX_EXIT -eq 0 ] && [ -f /tmp/codex-review-output.json ]; then
+  cat /tmp/codex-review-output.json
+else
+  STDERR_CONTENT=$(cat /tmp/codex-stderr.txt 2>/dev/null || echo "no stderr captured")
+  SAFE_STDERR=$(echo "$STDERR_CONTENT" | jq -Rs . 2>/dev/null || echo '"stderr encoding failed"')
+  printf '{"error": "Codex execution failed", "exit_code": %d, "stderr": %s}\n' "$CODEX_EXIT" "$SAFE_STDERR"
+fi
+
+rm -f /tmp/codex-review-schema.json /tmp/codex-review-output.json /tmp/codex-stderr.txt
+```
+
+### Bash call 2: Gemini Review
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+
+DIFF=$(git diff origin/main...HEAD)
+
+if [ -z "$DIFF" ]; then
+  printf '%s\n' '{"provider": "gemini", "model": "default", "findings": [], "summary": {"total_findings": 0, "critical": 0, "high": 0, "medium": 0, "low": 0, "quality_score": 10.0, "verdict": "APPROVE", "note": "No changes detected vs origin/main"}}'
+  exit 0
+fi
+
+printf '%s\n' "$DIFF" | gemini --model gemini-3-pro-preview -p "You are a senior code reviewer performing a thorough security-focused review.
+
+ANALYZE THIS DIFF FOR:
+1. Security vulnerabilities - injection, XSS, CSRF, auth issues, secrets exposure
+2. Architectural issues - coupling, layering violations, anti-patterns
+3. Logic errors - race conditions, null refs, wrong comparisons
+4. Performance - N+1 queries, memory leaks, blocking in async
+5. Test coverage gaps - missing edge cases, untested paths
+
+USE YOUR SEARCH CAPABILITY to check for:
+- Known CVEs in any dependencies mentioned
+- Security best practices for patterns used
+- Current recommendations for the frameworks detected
+
+RESPOND WITH ONLY THIS JSON (no markdown, no explanation):
+{
+  \"provider\": \"gemini\",
+  \"model\": \"default\",
+  \"findings\": [
+    {
+      \"severity\": \"critical|high|medium|low\",
+      \"category\": \"security|architecture|logic|performance|testing\",
+      \"file\": \"path/to/file\",
+      \"line\": 42,
+      \"title\": \"Brief descriptive title\",
+      \"description\": \"What is wrong and why it matters\",
+      \"suggestion\": \"Concrete fix recommendation\",
+      \"confidence\": 0.95
+    }
+  ],
+  \"summary\": {
+    \"total_findings\": 3,
+    \"critical\": 0,
+    \"high\": 1,
+    \"medium\": 2,
+    \"low\": 0,
+    \"quality_score\": 7.5,
+    \"verdict\": \"APPROVE|NEEDS_WORK|BLOCK\"
+  }
+}
+
+THE DIFF IS PROVIDED VIA STDIN ABOVE." \
+  --yolo \
+  -o json \
+  >/tmp/gemini-raw-output.json 2>/tmp/gemini-stderr.txt
+
+GEMINI_EXIT=$?
+if [ $GEMINI_EXIT -eq 0 ] && [ -f /tmp/gemini-raw-output.json ]; then
+  # Gemini -o json wraps output in session envelope; extract .response and strip markdown fences
+  RESPONSE=$(jq -r '.response // empty' /tmp/gemini-raw-output.json 2>/dev/null)
+  if [ -n "$RESPONSE" ]; then
+    echo "$RESPONSE" | sed 's/^```json//;s/^```//;/^$/d' | jq . 2>/dev/null || echo "$RESPONSE"
+  else
+    cat /tmp/gemini-raw-output.json
+  fi
+else
+  STDERR_CONTENT=$(cat /tmp/gemini-stderr.txt 2>/dev/null)
+  SAFE_STDERR=$(echo "$STDERR_CONTENT" | jq -Rs . 2>/dev/null || echo '"stderr encoding failed"')
+  printf '{"error": "Gemini execution failed", "exit_code": %d, "stderr": %s}\n' "$GEMINI_EXIT" "$SAFE_STDERR"
+fi
+rm -f /tmp/gemini-stderr.txt /tmp/gemini-raw-output.json
+```
+
+Collect both JSON outputs. Parse them. If either returned an error JSON, note it for arbitration.
+
+Output: "[TRIBUNAL 2/3] Reviews complete - Codex: {N} findings, Gemini: {M} findings"
+
+---
+
+## STEP 3: Inline Arbitration (Opus)
+
+Do NOT spawn a Task agent. You are already Opus -- perform arbitration directly.
+
+Read both JSON outputs from Step 2 and apply the following protocol:
+
+### 3a: Deduplicate Findings
+
+Two findings are **duplicates** if they describe the same underlying issue in the same file, even if worded differently. For duplicates:
+- Keep the finding with higher confidence
+- Merge suggestions if both are valuable
+- Mark as "CONSENSUS"
+
+### 3b: Resolve Conflicts
+
+| Scenario | Action |
+|----------|--------|
+| Both agree | Include, mark CONSENSUS |
+| Severity differs | **Use higher severity**, note disagreement in arbiter_notes |
+| Only Codex found it | Include as CODEX, evaluate validity |
+| Only Gemini found it | Include as GEMINI, evaluate validity |
+| Providers contradict | Decide and document reasoning, mark ARBITRATED |
+
+**HARD RULE**: When providers report different severities for the same finding, you MUST use the higher severity. No exceptions.
+
+### 3c: Evaluate Each Finding
+
+For each finding, assess:
+- Is this a real issue or a false positive?
+- Is the suggested fix correct and complete?
+- Does your software engineering expertise suggest a different conclusion?
+
+Override provider findings when they are clearly wrong. Add new findings if both providers missed something obvious.
+
+### 3d: Confidence Ranges
+
+| Finding type | Confidence range |
+|-------------|-----------------|
+| CONSENSUS | 0.85 - 0.99 |
+| Single-provider (CODEX/GEMINI) | 0.60 - 0.80 |
+| ARBITRATED (conflict resolved) | 0.50 - 0.70 |
+| Self-added (arbiter-originated) | 0.50 - 0.65 |
+
+### 3e: Degraded Input
+
+- If one provider returned invalid JSON or failed: proceed with the other provider's findings alone. Note the failure.
+- If **both providers failed**: verdict = NEEDS_WORK, confidence = 0.0, rationale = "Both review providers failed. Manual review required."
+- If **both providers returned zero findings**: verdict = APPROVE, confidence = 0.95.
+
+### 3f: Issue Verdict
+
+Assign finding IDs as T-001, T-002, etc., ordered by severity (critical first).
+
+Output the tribunal verdict as JSON:
+
+```json
+{
+  "tribunal_verdict": { "decision": "APPROVE|NEEDS_WORK|BLOCK", "confidence": 0.0, "rationale": "..." },
+  "findings": [{
+    "id": "T-001", "consensus": "CONSENSUS|CODEX|GEMINI|ARBITRATED",
+    "severity": "critical|high|medium|low", "category": "logic|security|performance|quality|architecture",
+    "file": "path/to/file", "line": 0, "title": "...", "description": "...",
+    "suggestion": "...", "confidence": 0.0, "arbiter_notes": "..."
+  }],
+  "conflicts_resolved": [{
+    "issue": "...", "codex_position": "...", "gemini_position": "...",
+    "ruling": "...", "reasoning": "..."
+  }],
+  "provider_assessment": {
+    "codex": { "findings_accepted": 0, "findings_rejected": 0, "false_positives": [], "status": "ok|failed|partial" },
+    "gemini": { "findings_accepted": 0, "findings_rejected": 0, "false_positives": [], "status": "ok|failed|partial" }
+  },
+  "summary": "2-3 sentence executive summary of code quality and required actions"
+}
+```
+
+Output: "[TRIBUNAL 3/3] Verdict: {APPROVE|NEEDS_WORK|BLOCK} - {N} actionable findings"
+
+---
+
+## Trust Hierarchy
+
+```
+OPUS 4.5 (Final authority, runs inline)
+    |
+CODEX (Trusted for logic)
+    |
+GEMINI (Advisory, verify findings)
+```
+
+Opus can override any Codex or Gemini finding.
+
+---
+
+## Quick Reference
+
+| Mode | Steps | Tool Calls | Agent Spawns |
+|------|-------|------------|-------------|
+| Default (review) | 3 | 2 (parallel Bash) | 0 |


### PR DESCRIPTION
## Summary
- Adds `gemini-cli` plugin integrating Google's Gemini CLI into Claude Code
- 4 slash commands: `/gemini-ask`, `/gemini-review`, `/gemini-second-opinion`, `/gemini-explain`
- Autonomous `using-gemini` skill for Claude Code to consult Gemini when beneficial
- Defaults to Gemini 3 preview models (`gemini-3-flash-preview`, `gemini-3-pro-preview`) with stable 2.5 fallback
- CLI reference documentation covering all flags, models, error patterns
- Registered in marketplace.json

## Test plan
- [ ] Install plugin: `/plugin install gemini-cli@paat-plugins`
- [ ] Verify `/gemini-ask what is 2+2` returns a Gemini response
- [ ] Verify `/gemini-review` performs dual AI code review on a file
- [ ] Verify `/gemini-explain` explains code or concepts via Gemini
- [ ] Verify `/gemini-second-opinion` synthesizes both AI perspectives
- [ ] Verify `--pro` and `--flash` model overrides work
- [ ] Confirm skill triggers when asking for "second opinion" or "ask gemini"

🤖 Generated with [Claude Code](https://claude.com/claude-code)