### PR TITLE
Add reddit-fetch plugin for Reddit research via Gemini CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,17 @@
       "source": "./plugins/gemini-cli",
       "category": "development",
       "homepage": "https://github.com/paat/claude-plugins"
+    },
+    {
+      "name": "reddit-fetch",
+      "description": "Research any topic using Reddit via Gemini CLI's web access capabilities",
+      "version": "0.1.0",
+      "author": {
+        "name": "Andre Paat"
+      },
+      "source": "./plugins/reddit-fetch",
+      "category": "research",
+      "homepage": "https://github.com/paat/claude-plugins"
     }
   ]
 }

--- a/plugins/reddit-fetch/.claude-plugin/plugin.json
+++ b/plugins/reddit-fetch/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "reddit-fetch",
+  "version": "0.1.0",
+  "description": "Research any topic using Reddit via Gemini CLI's web access capabilities",
+  "author": {
+    "name": "Andre Paat"
+  },
+  "repository": "https://github.com/paat/claude-plugins",
+  "license": "MIT",
+  "keywords": ["reddit", "research", "gemini", "web-search", "community"]
+}

--- a/plugins/reddit-fetch/README.md
+++ b/plugins/reddit-fetch/README.md
@@ -1,0 +1,62 @@
+# reddit-fetch
+
+Research any topic using Reddit via Gemini CLI's web access capabilities.
+
+Claude's WebFetch cannot access Reddit content. This plugin delegates Reddit research to Gemini CLI, which has full web access and can search, read, and summarize Reddit discussions.
+
+## Prerequisites
+
+1. **Gemini CLI** must be installed and authenticated:
+   ```bash
+   npm install -g @google/gemini-cli
+   gemini  # Run once interactively to complete OAuth
+   ```
+
+2. **Enable preview features** in `~/.gemini/settings.json`:
+   ```json
+   {
+     "general": {
+       "previewFeatures": true
+     }
+   }
+   ```
+   This is required to use the `gemini-3-flash-preview` model.
+
+> **Note:** This plugin does not install Gemini CLI. It must already be available in your PATH.
+
+## Components
+
+### Command: `/reddit-fetch <topic>`
+
+Quick slash command to research any topic on Reddit.
+
+```
+/reddit-fetch best static site generators 2025
+/reddit-fetch NixOS vs Arch Linux for development
+/reddit-fetch fix Docker compose networking issues
+```
+
+### Skill: reddit-research
+
+Automatically activates when you ask about community opinions, real-world experiences, or Reddit discussions. Provides prompt patterns and result formatting guidance.
+
+### Agent: reddit-researcher
+
+Triggers proactively when your question would benefit from Reddit community insights — tool comparisons, troubleshooting, community recommendations, etc.
+
+## How It Works
+
+1. Constructs a Reddit-focused prompt for Gemini CLI
+2. Calls `gemini -m gemini-3-flash-preview -p "..." -o text 2>/dev/null`
+3. Parses and presents Reddit findings in a structured format
+4. Adds caveats about anecdotal nature of Reddit opinions
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Empty response | Gemini may not find Reddit results — try more specific terms or subreddits |
+| Auth error | Run `gemini` interactively to re-authenticate OAuth |
+| Model not found | Enable `previewFeatures` in `~/.gemini/settings.json`, or fall back to `gemini-2.5-flash` |
+| Command not found | Install Gemini CLI: `npm install -g @google/gemini-cli` |
+| Timeout | Increase timeout or narrow the search scope |

--- a/plugins/reddit-fetch/agents/reddit-researcher.md
+++ b/plugins/reddit-fetch/agents/reddit-researcher.md
@@ -1,0 +1,93 @@
+---
+name: reddit-researcher
+description: Use this agent when the user needs real-world community opinions, experiences, or recommendations that Reddit discussions would provide. Triggers when users ask about community sentiment, tool/product comparisons from real users, troubleshooting with community-sourced solutions, or when Claude's WebFetch cannot access Reddit. Examples:
+
+  <example>
+  Context: User is evaluating technology choices and wants real-world feedback
+  user: "What do people actually think about using Tailwind CSS vs plain CSS modules?"
+  assistant: "Let me research what the community says about this comparison."
+  <commentary>
+  User wants real-world opinions and experiences comparing technologies - Reddit is an excellent source for this kind of community feedback.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User is troubleshooting an issue and wants community-sourced solutions
+  user: "I keep getting CORS errors with my Next.js API routes, has anyone else dealt with this?"
+  assistant: "Let me search Reddit for people who've encountered and solved this issue."
+  <commentary>
+  User is asking about a common problem and wants solutions that worked for others - Reddit threads often contain confirmed fixes.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to know what the community recommends
+  user: "What's the best self-hosted alternative to Notion?"
+  assistant: "I'll check what the self-hosting community on Reddit recommends."
+  <commentary>
+  User wants community recommendations based on real usage experience - subreddits like r/selfhosted are ideal for this.
+  </commentary>
+  </example>
+
+model: haiku
+color: red
+---
+
+You are a Reddit research specialist. Your job is to find and synthesize community discussions from Reddit on any given topic by using Gemini CLI, which has web access.
+
+**Your Core Responsibilities:**
+1. Research topics by searching Reddit via Gemini CLI
+2. Find relevant threads, opinions, and community consensus
+3. Present structured, useful findings
+4. Add context about the reliability and recency of the information
+
+**Process:**
+
+1. Analyze the user's question to determine:
+   - The core topic to research
+   - Whether specific subreddits are relevant (e.g., r/programming, r/selfhosted, r/webdev)
+   - Whether this is a comparison, recommendation, troubleshooting, or general opinion query
+
+2. Construct a targeted Gemini prompt. Always include "Search Reddit" and request structured output:
+   ```bash
+   timeout 120 gemini -m gemini-3-flash-preview -p "Search Reddit for [SPECIFIC QUERY]. Find the most relevant and recent threads. For each thread, provide: the subreddit, thread title, key opinions and advice from top comments, and any consensus or disagreements. Focus on practical, experience-based insights." -o text 2>/dev/null
+   ```
+
+3. If the first query returns empty or vague results, retry with:
+   - More specific subreddit targeting
+   - Rephrased search terms
+   - Narrower scope
+
+4. Present findings in this format:
+
+   ## Reddit Research: [Topic]
+
+   *Sourced from Reddit via Gemini CLI*
+
+   ### Key Findings
+   [Organized summary]
+
+   ### Popular Recommendations
+   [Bullet points with subreddit attribution]
+
+   ### Common Concerns
+   [Issues people mention]
+
+   ### Notable Threads
+   [Specific threads worth noting]
+
+   ### Caveats
+   - Reddit opinions are anecdotal and may not reflect current state
+   - Results depend on Gemini's web search coverage
+
+**Error Handling:**
+- If Gemini returns empty: Retry once with rephrased query
+- If Gemini times out: Retry with `timeout 180`
+- If Gemini is unavailable (auth error, not installed): Report the issue clearly and suggest the user check Gemini CLI installation and authentication
+- If model not found: Fall back to `gemini-2.5-flash`
+
+**Quality Standards:**
+- Always attribute findings to specific subreddits when possible
+- Distinguish between widely-held opinions and minority views
+- Note when information may be outdated
+- Never fabricate Reddit content — only report what Gemini finds

--- a/plugins/reddit-fetch/commands/reddit-fetch.md
+++ b/plugins/reddit-fetch/commands/reddit-fetch.md
@@ -29,6 +29,7 @@ The user wants to research the following topic on Reddit:
 
 3. If the response is empty or an error occurs:
    - Retry once with a rephrased or more specific query
+   - If a "model not found" error occurs, retry with `-m gemini-2.5-flash` (stable fallback)
    - If Gemini is still unavailable, inform the user and suggest alternatives (WebSearch, manual browsing)
 
 4. Present the findings in a structured format:

--- a/plugins/reddit-fetch/commands/reddit-fetch.md
+++ b/plugins/reddit-fetch/commands/reddit-fetch.md
@@ -1,0 +1,57 @@
+---
+allowed-tools: Bash(gemini:*)
+description: Research any topic using Reddit via Gemini CLI
+argument-hint: <topic to research on Reddit>
+---
+
+Research a topic by searching Reddit via Gemini CLI. Gemini has web access and can fetch Reddit content that Claude's WebFetch cannot.
+
+## Instructions
+
+The user wants to research the following topic on Reddit:
+
+**Topic:** $ARGUMENTS
+
+## Steps
+
+1. Analyze the topic and determine the best search approach:
+   - If the topic maps to specific subreddits, include them in the prompt
+   - If it's a comparison ("X vs Y"), use comparison framing
+   - If it's troubleshooting, focus on threads with solutions
+   - Otherwise, use a general research prompt
+
+2. Run the Gemini command with a Reddit-focused prompt:
+   ```bash
+   timeout 120 gemini -m gemini-3-flash-preview -p "Search Reddit for discussions about TOPIC. Find the most relevant and recent threads. For each thread, provide: the subreddit, thread title, key opinions and advice from top comments, and any consensus or disagreements. Focus on practical, experience-based insights rather than speculation." -o text 2>/dev/null
+   ```
+
+   Replace TOPIC with the user's actual topic, expanding it into a clear search query.
+
+3. If the response is empty or an error occurs:
+   - Retry once with a rephrased or more specific query
+   - If Gemini is still unavailable, inform the user and suggest alternatives (WebSearch, manual browsing)
+
+4. Present the findings in a structured format:
+
+   ```
+   ## Reddit Research: [Topic]
+
+   *Sourced from Reddit via Gemini CLI*
+
+   ### Key Findings
+   [Organized summary of what Reddit discussions reveal]
+
+   ### Popular Recommendations
+   [Bullet points of common advice/recommendations]
+
+   ### Common Concerns
+   [Issues or caveats people mention]
+
+   ### Notable Threads
+   [Specific threads worth reading, with subreddit and title]
+
+   ### Caveats
+   - Reddit opinions are anecdotal and may not reflect current state
+   ```
+
+5. After presenting Reddit's findings, add own analysis or synthesis where relevant — note agreements or disagreements with the Reddit consensus.

--- a/plugins/reddit-fetch/skills/reddit-research/SKILL.md
+++ b/plugins/reddit-fetch/skills/reddit-research/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: reddit-research
+description: This skill should be used when the user asks to "research on reddit", "what does reddit say about", "reddit opinions on", "search reddit for", "check reddit for", "reddit discussion about", "reddit recommendations for", "community feedback on", "what do people think about", "has anyone on reddit", or needs real-world user experiences, community opinions, troubleshooting solutions, or tool/product comparisons from Reddit. Also applies when Claude's WebFetch cannot access Reddit content.
+---
+
+# Reddit Research via Gemini CLI
+
+Research any topic using Reddit by delegating web searches to Gemini CLI, which has full web access and can fetch Reddit content that Claude's WebFetch cannot.
+
+## Prerequisites
+
+Gemini CLI must be installed (`npm install -g @google/gemini-cli`) and authenticated. Run `gemini` interactively once to complete OAuth login.
+
+Enable preview features in `~/.gemini/settings.json` to use `gemini-3-flash-preview`:
+
+```json
+{
+  "general": {
+    "previewFeatures": true
+  }
+}
+```
+
+## How It Works
+
+Gemini CLI has web access and can search, read, and summarize Reddit content. Construct prompts that instruct Gemini to:
+1. Search Reddit for the given topic
+2. Find relevant threads and discussions
+3. Extract key opinions, advice, and consensus
+4. Return structured findings
+
+## Crafting Effective Reddit Prompts
+
+### Basic Research Prompt
+
+```bash
+timeout 120 gemini -m gemini-3-flash-preview -p "Search Reddit for discussions about [TOPIC]. Find the most relevant and recent threads. For each thread, provide: the subreddit, thread title, key opinions and advice from top comments, and any consensus or disagreements. Focus on practical, experience-based insights." -o text 2>/dev/null
+```
+
+### Targeted Subreddit Prompt
+
+When the topic maps to a known subreddit, specify it:
+
+```bash
+timeout 120 gemini -m gemini-3-flash-preview -p "Search r/[SUBREDDIT] for discussions about [TOPIC]. Summarize the top threads, common recommendations, and community consensus." -o text 2>/dev/null
+```
+
+### Comparison/Recommendation Prompt
+
+For "X vs Y" or "best tool for Z" queries:
+
+```bash
+timeout 120 gemini -m gemini-3-flash-preview -p "Search Reddit for comparisons of [X] vs [Y]. Find threads where users share real-world experience with both. Summarize: which one users prefer and why, common pros/cons mentioned, and any dealbreakers people report." -o text 2>/dev/null
+```
+
+### Troubleshooting Prompt
+
+For debugging or problem-solving:
+
+```bash
+timeout 120 gemini -m gemini-3-flash-preview -p "Search Reddit for people who experienced [PROBLEM/ERROR]. Find threads with solutions that worked. Summarize: what caused the issue, which solutions were confirmed working, and any workarounds." -o text 2>/dev/null
+```
+
+## Prompt Construction Guidelines
+
+- Always include "Search Reddit" in the prompt so Gemini knows to look at Reddit specifically
+- Request structured output (thread titles, subreddits, key points)
+- Ask for "recent" threads when freshness matters
+- Specify subreddits when the domain is clear (e.g., r/programming, r/homelab, r/selfhosted)
+- Request "experience-based" or "practical" insights to filter out speculation
+- For technical topics, ask Gemini to prioritize threads with confirmed solutions
+
+## Model and Timeout
+
+- **Model**: Always use `-m gemini-3-flash-preview` — fast enough for research, good at web search
+- **Timeout**: Use `timeout 120` for standard research, `timeout 180` for broad or multi-topic queries
+- **Output**: Always use `-o text 2>/dev/null` for clean output. When troubleshooting, remove `2>/dev/null` to see Gemini CLI error messages
+
+## Presenting Results
+
+After receiving Gemini's response:
+
+1. **Label the source** — Clearly indicate this comes from Reddit via Gemini
+2. **Structure the findings** — Organize by theme, subreddit, or relevance
+3. **Highlight consensus** — Note where multiple threads agree
+4. **Flag caveats** — Reddit opinions may be biased, outdated, or anecdotal
+5. **Add own analysis** — Synthesize findings with own knowledge
+
+Example output format:
+
+```
+## Reddit Research: [Topic]
+
+*Sourced from Reddit via Gemini CLI*
+
+### Key Findings
+
+**Community consensus:** [summary]
+
+**Popular recommendations:**
+- [item 1] — mentioned in r/subreddit, r/subreddit2
+- [item 2] — recommended by multiple users in r/subreddit
+
+**Common concerns:**
+- [concern 1]
+- [concern 2]
+
+**Notable threads:**
+- r/subreddit: "[thread title]" — [key takeaway]
+- r/subreddit: "[thread title]" — [key takeaway]
+
+### Caveats
+- Reddit opinions are anecdotal and may not reflect current state
+- Results depend on Gemini's web search coverage
+```
+
+## Error Handling
+
+| Error | Action |
+|---|---|
+| Empty response | Retry with more specific subreddit or rephrased query |
+| Auth errors | Tell user to run `gemini` interactively to re-authenticate |
+| Timeout | Increase to 180s; if still fails, narrow the search scope |
+| Model not found | Fall back to `gemini-2.5-flash`. User may need to enable `previewFeatures` in `~/.gemini/settings.json` |
+| Gemini unavailable | Inform user; suggest they try WebSearch or manual Reddit browsing |
+
+If Gemini is unavailable, do not block the workflow. Proceed with available tools and note the limitation.


### PR DESCRIPTION
## Summary
- Adds `reddit-fetch` plugin that delegates Reddit content fetching to Gemini CLI (which has web access Claude's WebFetch lacks)
- Includes a skill (`reddit-research`), slash command (`/reddit-fetch <topic>`), and proactive agent (`reddit-researcher`)
- Uses `gemini-3-flash-preview` model; requires Gemini CLI installed with preview features enabled
- Adds marketplace entry for the new plugin

## Test plan
- [ ] Install plugin locally with `claude --plugin-dir plugins/reddit-fetch`
- [ ] Test `/reddit-fetch best static site generators` command
- [ ] Verify agent triggers on questions like "What does Reddit say about NixOS?"
- [ ] Verify skill loads on "search reddit for" type queries
- [ ] Confirm error handling when Gemini CLI is not available