### PR TITLE
Add agent-sync plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,6 +38,17 @@
       "source": "./plugins/tribunal-review",
       "category": "development",
       "homepage": "https://github.com/paat/claude-plugins"
+    },
+    {
+      "name": "agent-sync",
+      "description": "Generate AGENTS.md from Claude Code project configuration files",
+      "version": "0.1.0",
+      "author": {
+        "name": "Andre Paat"
+      },
+      "source": "./plugins/agent-sync",
+      "category": "development",
+      "homepage": "https://github.com/paat/claude-plugins"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Claude Plugins Repository
+
+## Rules
+
+- All plugins in this repo must be generic and project-agnostic
+- Project-specific values must use template variables, not hardcoded strings
+- No hardcoded project names, paths, stacks, or team conventions in plugin code
+- Plugins must work with bash 4+ and standard POSIX tools
+- External dependencies (jq, awk, sed) must be documented in README

--- a/plugins/agent-sync/.claude-plugin/plugin.json
+++ b/plugins/agent-sync/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "agent-sync",
+  "version": "0.1.0",
+  "description": "Generate AGENTS.md from Claude Code project configuration files (CLAUDE.md, .claude/rules/, settings.json, hooks)",
+  "author": {
+    "name": "Andre Paat"
+  },
+  "repository": "https://github.com/paat/claude-plugins",
+  "license": "MIT",
+  "keywords": ["agents-md", "sync", "codex", "copilot", "cursor", "amp", "config-sync"]
+}

--- a/plugins/agent-sync/LICENSE
+++ b/plugins/agent-sync/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Andre Paat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/agent-sync/README.md
+++ b/plugins/agent-sync/README.md
@@ -1,0 +1,105 @@
+# agent-sync
+
+Generate AGENTS.md from your Claude Code project configuration. Keep your `.claude/rules/`, `CLAUDE.md`, and `.claude/settings.json` as the source of truth — agent-sync assembles them into a single AGENTS.md that other AI coding tools (Codex, Copilot, Cursor, AMP) can read.
+
+## Prerequisites
+
+- `bash` 4+
+- `jq`
+- `awk`, `sed` (standard on Linux/macOS)
+
+## Quick Start
+
+```
+/agent-sync:init        # Scan project, create sources.json
+/agent-sync:generate    # Build AGENTS.md
+/agent-sync:check       # Verify AGENTS.md is in sync
+```
+
+## How It Works
+
+1. Your Claude Code config lives in `CLAUDE.md`, `.claude/rules/*.md`, `.claude/settings.json`, and `.claude/hooks/*.sh`
+2. `sources.json` maps these files to sections in AGENTS.md
+3. The generator reads each source, processes it (strip frontmatter, extract headings, shift heading levels), and assembles the output
+4. Template variables (`{{project_name}}`, `{{stack}}`, `{{primary_agent}}`) customize the header
+
+## Configuration
+
+Config file: `tools/agent-sync/sources.json` or `.agent-sync/sources.json`
+
+```jsonc
+{
+  "version": 2,
+  "variables": {
+    "project_name": "My Project",
+    "stack": "Node.js + React",
+    "primary_agent": "Claude Code"
+  },
+  "files": {
+    "architecture": ".claude/rules/architecture.md",
+    "codeStyle": ".claude/rules/code-style.md",
+    "settings": ".claude/settings.json"
+  },
+  "outputs": [
+    {
+      "path": "AGENTS.md",
+      "sections": [
+        { "id": "arch", "title": "Architecture", "source": "architecture", "type": "full-body" },
+        { "id": "style", "title": "Code Style", "source": "codeStyle", "type": "full-body" },
+        { "id": "settings", "title": "Settings", "source": "settings", "type": "settings" }
+      ]
+    }
+  ]
+}
+```
+
+### Section Types
+
+| Type | Description |
+|---|---|
+| `full-body` | Include entire file (frontmatter stripped, title removed, headings shifted +1) |
+| `extract` | Pull specific heading sections. Requires `headings` array. |
+| `settings` | Render `.claude/settings.json` as markdown tables (plugins, hooks, scripts) |
+
+### Subdirectory Outputs
+
+Generate scoped AGENTS.md files for subdirectories:
+
+```jsonc
+{
+  "outputs": [
+    { "path": "AGENTS.md", "sections": [...] },
+    {
+      "path": "src/frontend/AGENTS.md",
+      "parent": "../../AGENTS.md",
+      "sections": [
+        { "id": "fe", "title": "Frontend", "source": "frontendDesign", "type": "full-body" }
+      ]
+    }
+  ]
+}
+```
+
+## CI Integration
+
+Add drift detection to your CI pipeline. See `/agent-sync:init` to generate the workflow, or see `skills/agent-sync/references/github-actions-template.md`.
+
+## Migration from Node.js Version
+
+If you have an existing `tools/agent-sync/generate-agents.mjs`:
+
+1. Your `sources.json` with `version: 1` works as-is (auto-converted to v2 format)
+2. Add `variables` to `sources.json` if you want project name/stack in the header
+3. Add a `settings` section if you want the settings summary rendered
+4. Replace `node tools/agent-sync/generate-agents.mjs` with `/agent-sync:generate`
+
+## Components
+
+| Component | Type | Purpose |
+|---|---|---|
+| `/agent-sync:generate` | Command | Generate/update AGENTS.md |
+| `/agent-sync:check` | Command | Verify AGENTS.md is in sync |
+| `/agent-sync:init` | Command | Scaffold sources.json |
+| `agent-sync` | Skill | Usage reference and troubleshooting |
+| `sync-watcher` | Agent | Proactively checks sync when configs change |
+| PostToolUse hook | Hook | Warns when tracked source file is edited |

--- a/plugins/agent-sync/agents/sync-watcher.md
+++ b/plugins/agent-sync/agents/sync-watcher.md
@@ -1,0 +1,45 @@
+---
+name: sync-watcher
+description: |
+  Use this agent proactively when Claude edits files in .claude/rules/, CLAUDE.md, or .claude/settings.json to check if AGENTS.md needs regeneration.
+
+  <example>
+  Context: User asked to update architecture rules
+  user: "Update the architecture documentation in .claude/rules/architecture.md"
+  assistant: "I've updated the architecture rules. Let me check if AGENTS.md needs updating."
+  <commentary>
+  A tracked source file was modified, trigger sync-watcher to check staleness.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User modified CLAUDE.md workflow section
+  user: "Add a new command to the workflow section in CLAUDE.md"
+  assistant: "Done. Let me verify AGENTS.md is still in sync."
+  <commentary>
+  CLAUDE.md is typically a source file for agent-sync, check if regeneration is needed.
+  </commentary>
+  </example>
+model: haiku
+color: cyan
+tools: Bash, Read, Glob
+---
+
+# sync-watcher
+
+You check whether AGENTS.md is stale after Claude Code configuration files are modified.
+
+## Process
+
+1. Check if the project has agent-sync configured:
+   - Look for `tools/agent-sync/sources.json` or `.agent-sync/sources.json`
+   - If neither exists, report: "No agent-sync config found. Run `/agent-sync:init` to set up."
+
+2. Run the sync check:
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/generate.sh" --config "<path>" --check
+   ```
+
+3. Report results:
+   - **In sync**: "AGENTS.md is up to date."
+   - **Drift detected**: "AGENTS.md is out of sync with your config changes. Run `/agent-sync:generate` to update."

--- a/plugins/agent-sync/commands/check.md
+++ b/plugins/agent-sync/commands/check.md
@@ -1,0 +1,25 @@
+---
+allowed-tools: Bash, Read
+description: Verify AGENTS.md is in sync with Claude Code configuration files
+---
+
+# /agent-sync:check
+
+Verify that AGENTS.md is up to date with the project's Claude Code configuration.
+
+## What to do
+
+1. Locate the project's `sources.json` config file. Search in order:
+   - `tools/agent-sync/sources.json`
+   - `.agent-sync/sources.json`
+
+2. If no config found, tell the user to run `/agent-sync:init` first.
+
+3. Run the check:
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/generate.sh" --config "<path-to-sources.json>" --check
+   ```
+
+4. Report results clearly:
+   - **Pass**: "AGENTS.md is in sync with your Claude Code configuration."
+   - **Fail**: "AGENTS.md is out of sync. Run `/agent-sync:generate` to update."

--- a/plugins/agent-sync/commands/generate.md
+++ b/plugins/agent-sync/commands/generate.md
@@ -1,0 +1,37 @@
+---
+allowed-tools: Bash, Read, Write
+description: Generate or update AGENTS.md from Claude Code configuration files
+argument-hint: "[--check]"
+---
+
+# /agent-sync:generate
+
+Generate or update AGENTS.md from the project's Claude Code configuration files.
+
+## What to do
+
+1. Locate the project's `sources.json` config file. Search in order:
+   - `tools/agent-sync/sources.json`
+   - `.agent-sync/sources.json`
+
+2. If no config found, tell the user to run `/agent-sync:init` first.
+
+3. Run the generator script:
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/generate.sh" --config "<path-to-sources.json>"
+   ```
+
+4. Report results:
+   - Which output files were updated
+   - Which files were already up to date
+   - Any errors encountered
+
+## If `--check` is passed
+
+Run in check mode to verify AGENTS.md is in sync without modifying files:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/generate.sh" --config "<path-to-sources.json>" --check
+```
+
+Report pass/fail status. On failure, suggest running `/agent-sync:generate` to fix.

--- a/plugins/agent-sync/commands/init.md
+++ b/plugins/agent-sync/commands/init.md
@@ -1,0 +1,90 @@
+---
+allowed-tools: Bash, Read, Write, Glob, Grep, AskUserQuestion
+description: Scaffold sources.json by scanning existing Claude Code configuration
+argument-hint: "[directory]"
+---
+
+# /agent-sync:init
+
+Initialize agent-sync for this project by scanning existing Claude Code configuration files and creating `sources.json`.
+
+## What to do
+
+### 1. Scan for Claude Code config files
+
+Search the project root for these files:
+- `CLAUDE.md`
+- `.claude/rules/*.md`
+- `.claude/settings.json`
+- `.claude/hooks/*.sh`
+
+### 2. Ask the user for project metadata
+
+Use AskUserQuestion to collect:
+
+**project_name**: Ask "What is the project name?" with options derived from the directory name or package.json name.
+
+**stack**: Ask "What is the tech stack?" with options like:
+- Auto-detected from package.json, *.csproj, go.mod, etc.
+- Let user provide custom answer
+
+**primary_agent**: Ask "Which AI coding tool is the primary agent?" with options:
+- "Claude Code" (Recommended)
+- "Codex"
+- "Cursor"
+- "AMP"
+
+### 3. Group files into sections
+
+Map discovered files to logical sections:
+
+| File pattern | Section type | Suggested title |
+|---|---|---|
+| `.claude/rules/architecture*.md` | `full-body` | Architecture |
+| `.claude/rules/code-style*.md` | `full-body` | Code Style |
+| `.claude/rules/*.md` (other) | `full-body` | Title from filename |
+| `CLAUDE.md` | `extract` | Workflow (headings: auto-detect top-level headings) |
+| `.claude/settings.json` | `settings` | Claude Settings and Hooks |
+
+### 4. Detect subdirectory candidates
+
+If any `.claude/rules/*.md` files have prefixes suggesting subdirectories (e.g., `frontend-design.md` → `src/frontend/`), ask the user if they want a separate subdirectory AGENTS.md output.
+
+### 5. Write sources.json
+
+Write to `tools/agent-sync/sources.json` (preferred) or `.agent-sync/sources.json` (ask user).
+
+Create the directory if needed.
+
+### 6. Offer CI template
+
+Ask: "Do you want a GitHub Actions workflow for drift detection?"
+
+If yes, write `.github/workflows/agents-sync.yml` using this template:
+
+```yaml
+name: AGENTS.md Sync Check
+on:
+  pull_request:
+    paths:
+      - 'CLAUDE.md'
+      - '.claude/**'
+      - 'tools/agent-sync/sources.json'
+      - 'AGENTS.md'
+
+jobs:
+  check-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install jq
+        run: sudo apt-get install -y jq
+      - name: Check AGENTS.md sync
+        run: bash tools/agent-sync/generate.sh --check
+```
+
+Adapt the script path based on where generate.sh is installed.
+
+### 7. Generate
+
+Ask the user if they want to run `/agent-sync:generate` now.

--- a/plugins/agent-sync/hooks/hooks.json
+++ b/plugins/agent-sync/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Check if the file that was just edited/written matches a source path tracked by agent-sync. Look for tools/agent-sync/sources.json or .agent-sync/sources.json in the project root. If the config exists, check if the edited file path matches any value in the \"files\" object. If it matches, output EXACTLY: '[agent-sync] Source file changed. Run /agent-sync:generate to update AGENTS.md.' If no config exists or the file doesn't match, output nothing."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/agent-sync/scripts/generate.sh
+++ b/plugins/agent-sync/scripts/generate.sh
@@ -1,0 +1,626 @@
+#!/usr/bin/env bash
+# agent-sync: Generate AGENTS.md from Claude Code project configuration
+# Dependencies: bash 4+, jq, awk, sed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Defaults ---
+CHECK_MODE=false
+CONFIG_PATH=""
+REPO_ROOT=""
+
+# --- CLI parsing ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      CHECK_MODE=true
+      shift
+      ;;
+    --config)
+      CONFIG_PATH="$2"
+      shift 2
+      ;;
+    --root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: generate.sh [--check] [--config <path>] [--root <path>]"
+      echo ""
+      echo "  --check          Verify AGENTS.md is in sync (exit 1 if drift)"
+      echo "  --config <path>  Path to sources.json (default: auto-detect)"
+      echo "  --root <path>    Project root directory (default: parent of config dir)"
+      echo ""
+      echo "Auto-detection searches for:"
+      echo "  tools/agent-sync/sources.json"
+      echo "  .agent-sync/sources.json"
+      exit 0
+      ;;
+    *)
+      echo "[agent-sync] Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# --- Locate config ---
+find_config() {
+  local search_dir="${1:-.}"
+  for candidate in "tools/agent-sync/sources.json" ".agent-sync/sources.json"; do
+    if [[ -f "$search_dir/$candidate" ]]; then
+      echo "$search_dir/$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [[ -z "$CONFIG_PATH" ]]; then
+  if ! CONFIG_PATH="$(find_config "$(pwd)")"; then
+    echo "[agent-sync] No sources.json found. Run /agent-sync:init to create one." >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "[agent-sync] Config not found: $CONFIG_PATH" >&2
+  exit 1
+fi
+
+CONFIG_PATH="$(cd "$(dirname "$CONFIG_PATH")" && pwd)/$(basename "$CONFIG_PATH")"
+
+if [[ -z "$REPO_ROOT" ]]; then
+  config_dir="$(dirname "$CONFIG_PATH")"
+  parent_dir="$(dirname "$config_dir")"
+  dir_name="$(basename "$config_dir")"
+  if [[ "$dir_name" == "agent-sync" || "$dir_name" == ".agent-sync" ]]; then
+    if [[ "$(basename "$parent_dir")" == "tools" ]]; then
+      REPO_ROOT="$(dirname "$parent_dir")"
+    else
+      REPO_ROOT="$parent_dir"
+    fi
+  else
+    REPO_ROOT="$config_dir"
+  fi
+fi
+
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+
+# --- Dependency check ---
+for cmd in jq awk sed; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "[agent-sync] Missing dependency: $cmd" >&2
+    exit 1
+  fi
+done
+
+# --- Read config ---
+CONFIG="$(cat "$CONFIG_PATH")"
+
+# --- v1 → v2 compatibility ---
+# If config has "outputPath" + "sections" at top level (v1), wrap into outputs array
+config_version="$(echo "$CONFIG" | jq -r '.version // 1')"
+has_outputs="$(echo "$CONFIG" | jq 'has("outputs")')"
+has_output_path="$(echo "$CONFIG" | jq 'has("outputPath")')"
+
+if [[ "$has_output_path" == "true" && "$has_outputs" == "false" ]]; then
+  # v1 format: convert to v2
+  CONFIG="$(echo "$CONFIG" | jq '{
+    version: 2,
+    variables: (.variables // {}),
+    files: .files,
+    outputs: [{
+      path: .outputPath,
+      sections: .sections
+    }]
+  }')"
+fi
+
+# --- Validation ---
+validate_config() {
+  local files_json sections_json
+
+  files_json="$(echo "$CONFIG" | jq -r '.files // empty')"
+  if [[ -z "$files_json" ]]; then
+    echo "[agent-sync] Invalid config: files is required." >&2
+    exit 1
+  fi
+
+  local outputs_count
+  outputs_count="$(echo "$CONFIG" | jq '.outputs | length')"
+  if [[ "$outputs_count" -eq 0 ]]; then
+    echo "[agent-sync] Invalid config: outputs must be a non-empty array." >&2
+    exit 1
+  fi
+
+  # Validate each output's sections
+  local i=0
+  while [[ $i -lt $outputs_count ]]; do
+    local output_path section_count
+    output_path="$(echo "$CONFIG" | jq -r ".outputs[$i].path")"
+    section_count="$(echo "$CONFIG" | jq ".outputs[$i].sections | length")"
+
+    if [[ -z "$output_path" || "$output_path" == "null" ]]; then
+      echo "[agent-sync] Invalid config: output[$i] requires path." >&2
+      exit 1
+    fi
+
+    if [[ "$section_count" -eq 0 ]]; then
+      echo "[agent-sync] Invalid config: output '$output_path' has no sections." >&2
+      exit 1
+    fi
+
+    local j=0
+    while [[ $j -lt $section_count ]]; do
+      local sid stype ssource
+      sid="$(echo "$CONFIG" | jq -r ".outputs[$i].sections[$j].id")"
+      stype="$(echo "$CONFIG" | jq -r ".outputs[$i].sections[$j].type")"
+      ssource="$(echo "$CONFIG" | jq -r ".outputs[$i].sections[$j].source")"
+
+      if [[ -z "$sid" || "$sid" == "null" ]]; then
+        echo "[agent-sync] Invalid config: section requires id in output '$output_path'." >&2
+        exit 1
+      fi
+
+      if [[ "$stype" != "full-body" && "$stype" != "extract" && "$stype" != "settings" ]]; then
+        echo "[agent-sync] Invalid config: section '$sid' has unsupported type '$stype'." >&2
+        exit 1
+      fi
+
+      # Check source exists in files (settings type uses 'settings' key)
+      local source_exists
+      source_exists="$(echo "$CONFIG" | jq --arg s "$ssource" '.files | has($s)')"
+      if [[ "$source_exists" != "true" ]]; then
+        echo "[agent-sync] Invalid config: section '$sid' references unknown source '$ssource'." >&2
+        exit 1
+      fi
+
+      if [[ "$stype" == "extract" ]]; then
+        local headings_count
+        headings_count="$(echo "$CONFIG" | jq ".outputs[$i].sections[$j].headings | length // 0")"
+        if [[ "$headings_count" -eq 0 ]]; then
+          echo "[agent-sync] Invalid config: extract section '$sid' requires non-empty headings." >&2
+          exit 1
+        fi
+      fi
+
+      j=$((j + 1))
+    done
+
+    i=$((i + 1))
+  done
+}
+
+validate_config
+
+# --- Check source files exist ---
+check_source_files() {
+  local keys
+  keys="$(echo "$CONFIG" | jq -r '.files | keys[]')"
+  while IFS= read -r key; do
+    local rel_path abs_path
+    rel_path="$(echo "$CONFIG" | jq -r --arg k "$key" '.files[$k]')"
+    abs_path="$REPO_ROOT/$rel_path"
+    if [[ ! -f "$abs_path" ]]; then
+      echo "[agent-sync] Missing source file for '$key': $rel_path" >&2
+      exit 1
+    fi
+  done <<< "$keys"
+}
+
+check_source_files
+
+# --- Text processing functions ---
+
+# Strip YAML frontmatter from markdown
+strip_frontmatter() {
+  awk '
+    BEGIN { in_fm=0; found_end=0 }
+    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+    in_fm && /^---[[:space:]]*$/ { in_fm=0; found_end=1; next }
+    in_fm { next }
+    { print }
+  '
+}
+
+# Remove the first H1 heading and any blank lines immediately after it
+remove_title_heading() {
+  awk '
+    BEGIN { found=0; skipping_blanks=0 }
+    !found && /^[[:space:]]*$/ { next }
+    !found && /^#[[:space:]]+/ { found=1; skipping_blanks=1; next }
+    skipping_blanks && /^[[:space:]]*$/ { next }
+    { skipping_blanks=0; print }
+  '
+}
+
+# Shift heading levels by +1 (## becomes ###, etc.)
+shift_headings_up() {
+  sed -E 's/^(#{1,5})([[:space:]]+)/\1#\2/'
+}
+
+# Normalize heading text for comparison: lowercase, collapse whitespace
+normalize_heading() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[[:space:]]+/ /g' | sed 's/^ //;s/ $//'
+}
+
+# Extract content under a specific heading (up to next heading of same or higher level)
+extract_heading_content() {
+  local markdown="$1"
+  local heading_text="$2"
+  local target
+  target="$(normalize_heading "$heading_text")"
+
+  local result
+  result="$(echo "$markdown" | awk -v target="$target" '
+    function normalize(s) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+      s = tolower(s)
+      gsub(/[[:space:]]+/, " ", s)
+      return s
+    }
+
+    BEGIN { capturing=0; level=0; found=0 }
+
+    /^#{1,6}[[:space:]]+/ {
+      match($0, /^(#+)[[:space:]]+(.+)$/, m)
+      if (RSTART > 0) {
+        cur_level = length(m[1])
+        cur_text = normalize(m[2])
+
+        if (capturing && cur_level <= level) {
+          exit
+        }
+
+        if (!found && cur_text == target) {
+          found = 1
+          capturing = 1
+          level = cur_level
+          next
+        }
+      }
+    }
+
+    capturing { print }
+  ')"
+
+  # Trim leading/trailing blank lines
+  result="$(echo "$result" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}')"
+
+  if [[ -z "$result" ]]; then
+    echo "[agent-sync] Heading not found or empty: \"$heading_text\"" >&2
+    exit 1
+  fi
+
+  echo "$result"
+}
+
+# Read a source file, strip frontmatter
+read_source() {
+  local key="$1"
+  local rel_path
+  rel_path="$(echo "$CONFIG" | jq -r --arg k "$key" '.files[$k]')"
+  cat "$REPO_ROOT/$rel_path" | strip_frontmatter
+}
+
+# Get template variable value (with fallback to empty string)
+get_var() {
+  echo "$CONFIG" | jq -r --arg k "$1" '.variables[$k] // ""'
+}
+
+# Apply template variable substitution
+apply_variables() {
+  local text="$1"
+  local keys
+  keys="$(echo "$CONFIG" | jq -r '.variables // {} | keys[]' 2>/dev/null || true)"
+  while IFS= read -r key; do
+    [[ -z "$key" ]] && continue
+    local val
+    val="$(get_var "$key")"
+    text="${text//\{\{$key\}\}/$val}"
+  done <<< "$keys"
+  echo "$text"
+}
+
+# Extract first 2 comment lines from a shell script (after shebang)
+extract_hook_summary() {
+  local content="$1"
+  echo "$content" | awk '
+    /^#!/ { next }
+    /^#[[:space:]]/ {
+      sub(/^#[[:space:]]*/, "")
+      if (length($0) > 0) {
+        comments[++n] = $0
+        if (n >= 2) exit
+      }
+      next
+    }
+    n > 0 && !/^#/ { exit }
+  END {
+    sep = ""
+    for (i = 1; i <= n; i++) {
+      printf "%s%s", sep, comments[i]
+      sep = " "
+    }
+  }'
+}
+
+# --- Section rendering ---
+
+render_full_body_section() {
+  local title="$1"
+  local source_key="$2"
+
+  local content
+  content="$(read_source "$source_key")"
+  content="$(echo "$content" | remove_title_heading)"
+  content="$(echo "$content" | shift_headings_up)"
+
+  # Trim
+  content="$(echo "$content" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}')"
+
+  echo "## $title"
+  echo ""
+  echo "$content"
+}
+
+render_extract_section() {
+  local title="$1"
+  local source_key="$2"
+  local output_idx="$3"
+  local section_idx="$4"
+
+  local content
+  content="$(read_source "$source_key")"
+
+  local headings_count
+  headings_count="$(echo "$CONFIG" | jq ".outputs[$output_idx].sections[$section_idx].headings | length")"
+
+  # Check if single heading matches title
+  local is_single_match=false
+  if [[ "$headings_count" -eq 1 ]]; then
+    local single_heading
+    single_heading="$(echo "$CONFIG" | jq -r ".outputs[$output_idx].sections[$section_idx].headings[0]")"
+    local norm_heading norm_title
+    norm_heading="$(normalize_heading "$single_heading")"
+    norm_title="$(normalize_heading "$title")"
+    if [[ "$norm_heading" == "$norm_title" ]]; then
+      is_single_match=true
+    fi
+  fi
+
+  echo "## $title"
+  echo ""
+
+  local h=0
+  while [[ $h -lt $headings_count ]]; do
+    local heading
+    heading="$(echo "$CONFIG" | jq -r ".outputs[$output_idx].sections[$section_idx].headings[$h]")"
+
+    local extracted
+    extracted="$(extract_heading_content "$content" "$heading")"
+
+    if [[ "$is_single_match" == "true" ]]; then
+      echo "$extracted"
+    else
+      echo "### $heading"
+      echo ""
+      echo "$extracted"
+    fi
+
+    h=$((h + 1))
+    if [[ $h -lt $headings_count ]]; then
+      echo ""
+    fi
+  done
+}
+
+render_settings_section() {
+  local source_key="$1"
+  local rel_path
+  rel_path="$(echo "$CONFIG" | jq -r --arg k "$source_key" '.files[$k]')"
+  local raw
+  raw="$(cat "$REPO_ROOT/$rel_path")"
+
+  # Enabled plugins
+  local plugins
+  plugins="$(echo "$raw" | jq -r '
+    .enabledPlugins // {} | to_entries[] | select(.value == true) | "- `\(.key)`"
+  ' 2>/dev/null || true)"
+
+  # PostToolUse hooks from settings
+  local hook_rows
+  hook_rows="$(echo "$raw" | jq -r '
+    .hooks.PostToolUse // [] | .[] |
+    .matcher as $m |
+    (.hooks // [])[] |
+    "| `\($m // "(none)")` | `\(.command // "(none)")` | \(.timeout // "(none)") |"
+  ' 2>/dev/null || true)"
+
+  # Hook script summaries from source files
+  local hook_summaries=""
+  local file_keys
+  file_keys="$(echo "$CONFIG" | jq -r '.files | keys[]')"
+  while IFS= read -r key; do
+    local fpath
+    fpath="$(echo "$CONFIG" | jq -r --arg k "$key" '.files[$k]')"
+    if [[ "$fpath" == *.sh ]]; then
+      local script_content summary
+      script_content="$(cat "$REPO_ROOT/$fpath")"
+      summary="$(extract_hook_summary "$script_content")"
+      [[ -z "$summary" ]] && summary="No summary comment detected."
+      hook_summaries="${hook_summaries}| \`$fpath\` | $summary |
+"
+    fi
+  done <<< "$file_keys"
+
+  cat <<SETTINGS
+## Claude Settings and Hooks
+
+### Enabled Plugins (\`.claude/settings.json\`)
+
+${plugins:-"- None enabled"}
+
+### PostToolUse Hooks (\`.claude/settings.json\`)
+
+| Matcher | Command | Timeout (s) |
+|---|---|---|
+${hook_rows:-"| \`(none)\` | \`(none)\` | \`(none)\` |"}
+
+### Hook Script Summaries
+
+| Script | Purpose |
+|---|---|
+${hook_summaries:-"| \`(none)\` | No hook scripts configured. |"}
+
+### Notes
+
+- Keep \`.claude/settings.json\` as the source of truth for Claude runtime behavior.
+- Edit hook scripts in \`.claude/hooks/\`; regenerate this file after changes.
+SETTINGS
+}
+
+# --- Build source file list ---
+build_source_list() {
+  local keys
+  keys="$(echo "$CONFIG" | jq -r '.files | keys[]')"
+  while IFS= read -r key; do
+    local fpath
+    fpath="$(echo "$CONFIG" | jq -r --arg k "$key" '.files[$k]')"
+    echo "- \`$fpath\`"
+  done <<< "$keys" | sort
+}
+
+# --- Render a single output ---
+render_output() {
+  local output_idx="$1"
+
+  local output_path parent_path
+  output_path="$(echo "$CONFIG" | jq -r ".outputs[$output_idx].path")"
+  parent_path="$(echo "$CONFIG" | jq -r ".outputs[$output_idx].parent // empty")"
+
+  local section_count
+  section_count="$(echo "$CONFIG" | jq ".outputs[$output_idx].sections | length")"
+
+  local project_name stack primary_agent
+  project_name="$(get_var "project_name")"
+  stack="$(get_var "stack")"
+  primary_agent="$(get_var "primary_agent")"
+
+  # Build header
+  local header=""
+  header+="# AGENTS.md"
+  [[ -n "$project_name" ]] && header+=" - $project_name"
+  header+=$'\n\n'
+  header+="> AUTO-GENERATED FILE. Do not edit directly."$'\n'
+  header+="> Generator: \`agent-sync\`"$'\n'
+  header+=$'\n'
+
+  if [[ -n "$primary_agent" || -n "$stack" ]]; then
+    local meta=""
+    [[ -n "$primary_agent" ]] && meta+="**Primary Agent:** $primary_agent"
+    [[ -n "$primary_agent" && -n "$stack" ]] && meta+=" | "
+    [[ -n "$stack" ]] && meta+="**Stack:** $stack"
+    header+="$meta"$'\n\n'
+  fi
+
+  # Parent back-reference for subdirectory outputs
+  if [[ -n "$parent_path" ]]; then
+    header+="> See also: [$parent_path]($parent_path)"$'\n\n'
+  fi
+
+  # Source of truth section (only for root/main output)
+  if [[ -z "$parent_path" ]]; then
+    header+="## Source of Truth"$'\n\n'
+    header+="$(build_source_list)"$'\n'
+  fi
+
+  # Apply variables (command substitution strips trailing newlines, so re-add)
+  header="$(apply_variables "$header")"$'\n'
+
+  # Render sections
+  local body=""
+  local s=0
+  while [[ $s -lt $section_count ]]; do
+    local stitle stype ssource
+    stitle="$(echo "$CONFIG" | jq -r ".outputs[$output_idx].sections[$s].title")"
+    stype="$(echo "$CONFIG" | jq -r ".outputs[$output_idx].sections[$s].type")"
+    ssource="$(echo "$CONFIG" | jq -r ".outputs[$output_idx].sections[$s].source")"
+
+    local section_content=""
+    case "$stype" in
+      full-body)
+        section_content="$(render_full_body_section "$stitle" "$ssource")"
+        ;;
+      extract)
+        section_content="$(render_extract_section "$stitle" "$ssource" "$output_idx" "$s")"
+        ;;
+      settings)
+        section_content="$(render_settings_section "$ssource")"
+        ;;
+    esac
+
+    body+=$'\n'"$section_content"$'\n'
+    s=$((s + 1))
+  done
+
+  # Apply variables (command substitution strips trailing newlines, so re-add)
+  body="$(apply_variables "$body")"$'\n'
+
+  # See Also footer (only for root/main output)
+  local footer=""
+  if [[ -z "$parent_path" ]]; then
+    footer=$'\n'"## See Also"$'\n\n'
+    footer+="- \`.claude/rules/\`"$'\n'
+    footer+="- \`.claude/settings.json\`"$'\n'
+    footer+="- \`CLAUDE.md\`"$'\n'
+  fi
+
+  echo "${header}${body}${footer}"
+}
+
+# --- Main ---
+outputs_count="$(echo "$CONFIG" | jq '.outputs | length')"
+
+exit_code=0
+i=0
+while [[ $i -lt $outputs_count ]]; do
+  output_path="$(echo "$CONFIG" | jq -r ".outputs[$i].path")"
+  abs_output="$REPO_ROOT/$output_path"
+
+  rendered="$(render_output "$i")"
+
+  if [[ "$CHECK_MODE" == "true" ]]; then
+    existing=""
+    if [[ -f "$abs_output" ]]; then
+      existing="$(cat "$abs_output")"
+    fi
+
+    if [[ "$existing" != "$rendered" ]]; then
+      echo "[agent-sync] DRIFT: $output_path is out of sync. Run: /agent-sync:generate" >&2
+      exit_code=1
+    else
+      echo "[agent-sync] OK: $output_path is in sync."
+    fi
+  else
+    existing=""
+    if [[ -f "$abs_output" ]]; then
+      existing="$(cat "$abs_output")"
+    fi
+
+    if [[ "$existing" == "$rendered" ]]; then
+      echo "[agent-sync] No changes: $output_path already up to date."
+    else
+      # Ensure parent directory exists
+      mkdir -p "$(dirname "$abs_output")"
+      echo "$rendered" > "$abs_output"
+      echo "[agent-sync] Updated $output_path."
+    fi
+  fi
+
+  i=$((i + 1))
+done
+
+exit $exit_code

--- a/plugins/agent-sync/skills/agent-sync/SKILL.md
+++ b/plugins/agent-sync/skills/agent-sync/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: agent-sync
+description: "Use when the user asks about AGENTS.md generation, agent-sync configuration, sources.json format, syncing Claude Code config to other AI tools, or troubleshooting agent-sync issues. Triggers: 'agents.md', 'agent sync', 'sync agents', 'sources.json', 'generate agents', 'agents file', 'codex config', 'copilot config', 'cursor rules', 'amp config'"
+---
+
+# agent-sync
+
+agent-sync generates AGENTS.md from Claude Code project configuration files (CLAUDE.md, .claude/rules/, settings.json, hooks). This makes your Claude Code setup available to other AI coding tools (Codex, Copilot, Cursor, AMP) that read AGENTS.md.
+
+## Quick Start
+
+1. **Initialize**: `/agent-sync:init` — scans your project, creates `sources.json`
+2. **Generate**: `/agent-sync:generate` — builds AGENTS.md from your config
+3. **Check**: `/agent-sync:check` — verifies AGENTS.md is in sync
+
+## How It Works
+
+The generator reads `sources.json` which maps Claude Code config files to sections in AGENTS.md:
+
+- **full-body** sections include the entire file (frontmatter stripped, headings shifted +1)
+- **extract** sections pull specific heading sections from a file
+- **settings** sections render `.claude/settings.json` as readable markdown tables
+
+Template variables (`{{project_name}}`, `{{stack}}`, `{{primary_agent}}`) are substituted in the generated header.
+
+## Configuration
+
+Config lives at `tools/agent-sync/sources.json` or `.agent-sync/sources.json`. See `references/sources-json-format.md` for the full schema.
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `/agent-sync:generate` | Generate/update AGENTS.md |
+| `/agent-sync:check` | Verify sync status |
+| `/agent-sync:init` | Create sources.json from existing config |
+
+## Troubleshooting
+
+### "Heading not found" error
+The extract section references a heading that doesn't exist in the source file. Check spelling and case — matching is case-insensitive but the heading text must match.
+
+### "Missing source file" error
+A file listed in `sources.json` `files` doesn't exist. Update the path or remove the entry.
+
+### Drift detected
+AGENTS.md is out of date with your Claude Code config. Run `/agent-sync:generate` to update.
+
+### Subdirectory outputs
+Add multiple entries to the `outputs` array, each with its own `path` and `sections`. Use `parent` to add a back-reference link to the root AGENTS.md.

--- a/plugins/agent-sync/skills/agent-sync/references/github-actions-template.md
+++ b/plugins/agent-sync/skills/agent-sync/references/github-actions-template.md
@@ -1,0 +1,58 @@
+# GitHub Actions Template for AGENTS.md Drift Detection
+
+## Workflow
+
+Add this to `.github/workflows/agents-sync.yml`:
+
+```yaml
+name: AGENTS.md Sync Check
+
+on:
+  pull_request:
+    paths:
+      - 'CLAUDE.md'
+      - '.claude/**'
+      - 'tools/agent-sync/sources.json'
+      - '.agent-sync/sources.json'
+      - 'AGENTS.md'
+      - '**/AGENTS.md'
+
+jobs:
+  check-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Check AGENTS.md sync
+        run: |
+          # Find the generate script
+          if [ -f "tools/agent-sync/generate.sh" ]; then
+            bash tools/agent-sync/generate.sh --check
+          elif [ -f ".agent-sync/generate.sh" ]; then
+            bash .agent-sync/generate.sh --check
+          else
+            echo "agent-sync generate.sh not found. Copy it from the plugin or install agent-sync."
+            exit 1
+          fi
+```
+
+## Setup
+
+To use this workflow, copy `generate.sh` from the agent-sync plugin into your project:
+
+```bash
+mkdir -p tools/agent-sync
+cp "$(claude plugin path agent-sync)/scripts/generate.sh" tools/agent-sync/generate.sh
+```
+
+Or reference the plugin script directly if the plugin is installed in CI.
+
+## What It Does
+
+- Triggers on PRs that modify Claude Code config files or AGENTS.md
+- Runs `generate.sh --check` to verify AGENTS.md matches current config
+- Fails the check if drift is detected
+- Suggests running `/agent-sync:generate` to fix

--- a/plugins/agent-sync/skills/agent-sync/references/sources-json-format.md
+++ b/plugins/agent-sync/skills/agent-sync/references/sources-json-format.md
@@ -1,0 +1,147 @@
+# sources.json Format Reference
+
+## Schema
+
+```jsonc
+{
+  "version": 2,
+  "variables": {
+    "project_name": "My Project",
+    "stack": ".NET 9 + React 19",
+    "primary_agent": "Claude Code"
+  },
+  "files": {
+    "claude": "CLAUDE.md",
+    "architecture": ".claude/rules/architecture.md",
+    "codeStyle": ".claude/rules/code-style.md",
+    "settings": ".claude/settings.json",
+    "hookLint": ".claude/hooks/post-edit-lint.sh"
+  },
+  "outputs": [
+    {
+      "path": "AGENTS.md",
+      "sections": [
+        { "id": "arch", "title": "Architecture", "source": "architecture", "type": "full-body" },
+        { "id": "style", "title": "Code Style", "source": "codeStyle", "type": "full-body" },
+        { "id": "workflow", "title": "Workflow", "source": "claude", "type": "extract", "headings": ["Development Workflow", "Commands"] },
+        { "id": "settings", "title": "Claude Settings and Hooks", "source": "settings", "type": "settings" }
+      ]
+    }
+  ]
+}
+```
+
+## Top-Level Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `version` | number | Yes | Config version. Use `2`. Version `1` is auto-converted. |
+| `variables` | object | No | Template variables substituted in the generated header |
+| `files` | object | Yes | Map of source key → relative file path from project root |
+| `outputs` | array | Yes | Array of output file configurations |
+
+## Variables
+
+Template variables are substituted as `{{variable_name}}` in the generated header.
+
+| Variable | Used in |
+|---|---|
+| `project_name` | Title: `# AGENTS.md - {{project_name}}` |
+| `stack` | Meta line: `**Stack:** {{stack}}` |
+| `primary_agent` | Meta line: `**Primary Agent:** {{primary_agent}}` |
+
+Custom variables are also supported and substituted throughout the output.
+
+## Files
+
+Keys are arbitrary identifiers referenced by section `source` fields. Values are paths relative to the project root.
+
+```json
+{
+  "architecture": ".claude/rules/architecture.md",
+  "settings": ".claude/settings.json"
+}
+```
+
+## Outputs
+
+Each output defines a generated file with its own sections.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `path` | string | Yes | Output file path relative to project root |
+| `parent` | string | No | Relative path to parent AGENTS.md (adds back-reference link) |
+| `sections` | array | Yes | Sections to include in this output |
+
+### Subdirectory Outputs
+
+```json
+{
+  "outputs": [
+    { "path": "AGENTS.md", "sections": [...] },
+    {
+      "path": "src/frontend/AGENTS.md",
+      "parent": "../../AGENTS.md",
+      "sections": [
+        { "id": "fe-design", "title": "Frontend Design", "source": "frontendDesign", "type": "full-body" }
+      ]
+    }
+  ]
+}
+```
+
+## Section Types
+
+### `full-body`
+
+Includes the entire source file. Processing:
+1. YAML frontmatter is stripped
+2. Title heading (first `# ...`) is removed
+3. All headings are shifted +1 level (`##` → `###`, etc.)
+4. Section gets a `## Title` heading
+
+```json
+{ "id": "arch", "title": "Architecture", "source": "architecture", "type": "full-body" }
+```
+
+### `extract`
+
+Pulls specific heading sections from a source file.
+
+```json
+{
+  "id": "workflow",
+  "title": "Workflow",
+  "source": "claude",
+  "type": "extract",
+  "headings": ["Development Workflow", "Commands"]
+}
+```
+
+- Each heading is matched case-insensitively
+- Content is extracted from the heading to the next heading of equal or higher level
+- If a single heading matches the section title, no sub-heading is added
+- If multiple headings, each gets a `### Heading` wrapper
+
+### `settings`
+
+Renders `.claude/settings.json` as markdown tables showing enabled plugins, PostToolUse hooks, and hook script summaries.
+
+```json
+{ "id": "settings", "title": "Claude Settings and Hooks", "source": "settings", "type": "settings" }
+```
+
+## v1 Compatibility
+
+Version 1 configs with `outputPath` + `sections` at the top level are automatically converted to version 2 format:
+
+```json
+{
+  "version": 1,
+  "outputPath": "AGENTS.md",
+  "files": { ... },
+  "sections": [ ... ]
+}
+```
+
+This is equivalent to a v2 config with a single output.


### PR DESCRIPTION
## Summary

- Adds `agent-sync` plugin — a portable (bash+jq) tool that generates AGENTS.md from Claude Code project configuration files
- Makes Claude Code config (CLAUDE.md, .claude/rules/, settings.json, hooks) available to other AI coding tools (Codex, Copilot, Cursor, AMP)
- Adds project-level CLAUDE.md with rules for generic, project-agnostic plugins
- Registers agent-sync in marketplace.json

## Components

| Component | Type | Purpose |
|---|---|---|
| `/agent-sync:generate` | Command | Generate/update AGENTS.md from config |
| `/agent-sync:check` | Command | Verify AGENTS.md is in sync |
| `/agent-sync:init` | Command | Scaffold sources.json by scanning .claude/ |
| `agent-sync` | Skill | Usage reference and troubleshooting |
| `sync-watcher` | Agent | Proactively checks sync when configs change |
| PostToolUse hook | Hook | Warns when tracked source file is edited |
| `scripts/generate.sh` | Script | Bash+jq generator (627 lines) |

## Key Features

- **Section types**: full-body (entire file), extract (specific headings), settings (renders settings.json as tables)
- **Template variables**: `{{project_name}}`, `{{stack}}`, `{{primary_agent}}` in generated header
- **Multi-output**: Generate root + subdirectory AGENTS.md files
- **v1 compatibility**: Existing configs with `outputPath` + `sections` auto-convert to v2 format
- **Drift detection**: `--check` mode for CI integration
- **CI template**: GitHub Actions workflow for automated sync checks

## Test plan

- [x] Tested `generate.sh` against novarc-pm2's existing sources.json config
- [x] Verified `--check` mode passes after generation
- [x] Verified `--help` output
- [x] Validated plugin structure with plugin-validator agent
- [x] All JSON files pass `jq` validation
- [x] Script passes `bash -n` syntax check