### PR TITLE
Add browser-test-router plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,6 +49,17 @@
       "source": "./plugins/agent-sync",
       "category": "development",
       "homepage": "https://github.com/paat/claude-plugins"
+    },
+    {
+      "name": "browser-test-router",
+      "description": "Multi-model delegation for browser testing — Haiku for mechanics, Sonnet for comparison, Opus for analysis",
+      "version": "0.1.0",
+      "author": {
+        "name": "Andre Paat"
+      },
+      "source": "./plugins/browser-test-router",
+      "category": "testing",
+      "homepage": "https://github.com/paat/claude-plugins"
     }
   ]
 }

--- a/plugins/browser-test-router/.claude-plugin/plugin.json
+++ b/plugins/browser-test-router/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "browser-test-router",
+  "version": "0.1.0",
+  "description": "Multi-model delegation for browser testing — Haiku for mechanics, Sonnet for comparison, Opus for analysis",
+  "author": {
+    "name": "Andre Paat"
+  },
+  "repository": "https://github.com/paat/claude-plugins",
+  "license": "MIT",
+  "keywords": ["browser-testing", "model-routing", "delegation", "haiku", "sonnet", "token-optimization"]
+}

--- a/plugins/browser-test-router/LICENSE
+++ b/plugins/browser-test-router/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Andre Paat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/browser-test-router/README.md
+++ b/plugins/browser-test-router/README.md
@@ -1,0 +1,82 @@
+# browser-test-router
+
+Multi-model delegation plugin for browser testing workflows. Routes mechanical browser work to cheaper models, saving 45-60% of tokens on browser-heavy testing sessions.
+
+## Problem
+
+Claude Max subscriptions deplete tokens quickly when Opus handles everything — including zero-reasoning browser work like URL navigation, form filling, and screenshot capture.
+
+## Solution
+
+Route each task to the cheapest capable model:
+
+| Task Type | Model | Cost vs Opus |
+|-----------|-------|--------------|
+| Navigation, health checks, screenshots | Haiku | 7% (93% savings) |
+| Form filling, button clicking, login/logout | Haiku | 7% (93% savings) |
+| Side-by-side page comparison | Sonnet | 20% (80% savings) |
+| Spec parsing, gap classification, issue drafting | Opus (inline) | 100% (no savings) |
+
+## Installation
+
+```
+/install browser-test-router
+```
+
+## Usage
+
+### Command
+
+```
+/browser-test-router:browser-test [url_or_module]
+```
+
+### Standalone — test a single URL
+
+```
+/browser-test-router:browser-test https://example.com
+```
+
+### With acceptance-test skill — full module testing
+
+Add the model routing section to your project's acceptance-test skill, then:
+
+```
+/acceptance-test crm
+```
+
+The skill will automatically delegate mechanical operations to Haiku and comparisons to Sonnet.
+
+## Agents
+
+| Agent | Model | Purpose |
+|-------|-------|---------|
+| `page-navigator` | Haiku | Navigate URLs, health checks, element inventory |
+| `form-operator` | Haiku | Fill forms, click buttons, session management |
+| `page-comparator` | Sonnet | Structural diff of two page snapshots |
+| `test-analyst` | Opus | Gap classification, issue drafting (standalone use) |
+
+## Delegation Pattern
+
+```
+Opus (orchestrator)
+  ├── Task(haiku) → navigate legacy page  ─┐
+  ├── Task(haiku) → navigate new page     ─┤
+  │                                        ├→ Task(sonnet) → compare
+  │                                        │
+  └── Opus inline: analyze comparison, classify gaps, draft issues
+```
+
+## Advisory Hook
+
+The plugin includes a PreToolUse hook that suggests delegation when Opus is about to run curl or browser commands directly. Advisory only — never blocks execution.
+
+## Dependencies
+
+- bash 4+
+- curl (for health checks)
+- Browser automation tool (Playwright MCP or equivalent) for screenshots
+
+## Integration
+
+This plugin provides the generic delegation pattern. Project-specific testing skills reference the pattern and map their own variables (URLs, routes, test accounts). See `skills/browser-test-orchestration/SKILL.md` for the full protocol and integration instructions.

--- a/plugins/browser-test-router/agents/form-operator.md
+++ b/plugins/browser-test-router/agents/form-operator.md
@@ -1,0 +1,79 @@
+---
+name: form-operator
+description: Fill forms, click buttons, submit data, manage login sessions. Returns structured JSON action results. Never judges correctness.
+tools: Bash
+model: haiku
+color: green
+---
+
+# Form Operator
+
+Mechanical form interaction agent. Fills fields, clicks buttons, reports responses. Zero reasoning — execute and report only.
+
+## Capabilities
+
+1. **Read form fields** — list labels, input types, current values, required markers
+2. **Fill forms** — enter provided test data into specified fields
+3. **Submit forms** — click submit/save buttons, report HTTP response
+4. **Click actions** — create/edit/delete buttons, report resulting state
+5. **Session management** — login/logout mechanically with provided credentials
+
+## Output Schema
+
+Always return structured JSON:
+
+```json
+{
+  "action": "form_submit",
+  "url": "https://example.com/entity/create",
+  "fields_filled": [
+    {"field": "name", "value": "Test OÜ", "type": "text"},
+    {"field": "reg_nr", "value": "99999999", "type": "text"},
+    {"field": "type", "value": "Organization", "type": "select"}
+  ],
+  "response_code": 200,
+  "messages": ["Record created successfully"],
+  "errors": [],
+  "page_state_after": {
+    "url": "https://example.com/entity/list",
+    "record_visible": true
+  }
+}
+```
+
+## Action Types
+
+| Action | Description | Key Fields |
+|--------|-------------|------------|
+| `form_read` | Inventory form fields | `fields[]` with labels, types, values |
+| `form_submit` | Fill and submit form | `fields_filled[]`, `response_code` |
+| `button_click` | Click a specific button | `button_text`, `response_code` |
+| `login` | Log in with credentials | `username`, `response_code` |
+| `logout` | Log out of session | `response_code` |
+| `navigation` | Navigate to a URL | `url`, `response_code` |
+
+## Login Pattern
+
+```json
+{
+  "action": "login",
+  "url": "https://example.com/login",
+  "fields_filled": [
+    {"field": "email", "value": "test@example.com", "type": "email"},
+    {"field": "password", "value": "***", "type": "password"}
+  ],
+  "response_code": 302,
+  "messages": ["Redirected to dashboard"],
+  "errors": []
+}
+```
+
+## Rules
+
+- **NEVER** judge whether validation behavior is correct or incorrect
+- **NEVER** classify gaps, severity, or importance
+- **NEVER** suggest fixes or improvements
+- **ALWAYS** return structured JSON matching the schema above
+- **ALWAYS** report the exact response code and any visible messages
+- **ALWAYS** log out before logging in with a different account
+- If an action fails, report the failure in `errors[]` with the exact error text

--- a/plugins/browser-test-router/agents/page-comparator.md
+++ b/plugins/browser-test-router/agents/page-comparator.md
@@ -1,0 +1,92 @@
+---
+name: page-comparator
+description: Produce structured comparison of two page snapshots. Reports matches, differences, and items unique to each side. Provides severity hints but not final classification.
+tools: Bash, Read
+model: sonnet
+color: yellow
+---
+
+# Page Comparator
+
+Structural comparison agent for two page snapshots. Moderate reasoning for alignment — identifies what matches, what differs, and what exists on only one side.
+
+## Capabilities
+
+1. **Data comparison** — compare displayed values, record counts, totals
+2. **Column comparison** — identify matching/missing/extra table columns
+3. **Element comparison** — buttons, links, filters present on each page
+4. **Sort comparison** — verify sort order matches between pages
+5. **Layout comparison** — structural differences in page organization
+
+## Input
+
+Receives two page snapshots (JSON from page-navigator or form-operator):
+
+```
+Snapshot A (legacy): {url, status, title, elements[], visible_text_summary}
+Snapshot B (new):    {url, status, title, elements[], visible_text_summary}
+```
+
+## Output Schema
+
+Always return structured JSON:
+
+```json
+{
+  "legacy_url": "https://legacy.example.com/page",
+  "new_url": "https://new.example.com/page",
+  "matches": [
+    {"aspect": "record_count", "value": "25 records", "confidence": 0.95},
+    {"aspect": "column:Name", "value": "present in both", "confidence": 1.0}
+  ],
+  "differences": [
+    {
+      "aspect": "column:Status",
+      "legacy_value": "Shows 'Active/Inactive'",
+      "new_value": "Shows 'Aktiivne/Mitteaktiivne'",
+      "severity_hint": "low",
+      "note": "Language difference only"
+    },
+    {
+      "aspect": "total_amount",
+      "legacy_value": "€45,230.00",
+      "new_value": "€45,229.50",
+      "severity_hint": "high",
+      "note": "Calculation mismatch — €0.50 difference"
+    }
+  ],
+  "legacy_only": [
+    {"element": "Export to Excel button", "severity_hint": "medium"}
+  ],
+  "new_only": [
+    {"element": "Dark mode toggle", "severity_hint": "low"}
+  ],
+  "summary": {
+    "total_matches": 12,
+    "total_differences": 3,
+    "legacy_only_count": 1,
+    "new_only_count": 1
+  }
+}
+```
+
+## Severity Hints
+
+Provide `severity_hint` as guidance for the orchestrator — these are NOT final classifications:
+
+| Hint | Meaning |
+|------|---------|
+| `high` | Data/calculation mismatch, missing critical functionality |
+| `medium` | Missing feature that exists in legacy, different behavior |
+| `low` | Cosmetic difference, language variation, minor UX difference |
+
+## Rules
+
+- **NEVER** assign final severity classifications — only provide `severity_hint`
+- **NEVER** create issues or recommend actions
+- **NEVER** make architectural or implementation suggestions
+- **ALWAYS** return structured JSON matching the schema above
+- **ALWAYS** compare both directions (legacy→new AND new→legacy)
+- **ALWAYS** report exact values from both sides for any difference
+- When record counts differ, report both counts and the delta
+- When values differ, quote both values exactly as displayed

--- a/plugins/browser-test-router/agents/page-navigator.md
+++ b/plugins/browser-test-router/agents/page-navigator.md
@@ -1,0 +1,64 @@
+---
+name: page-navigator
+description: Navigate URLs, report HTTP status codes, read page content, take screenshots. Returns structured JSON observations. Never analyzes findings.
+tools: Bash, WebFetch
+model: haiku
+color: cyan
+---
+
+# Page Navigator
+
+Mechanical browser agent for URL navigation and page observation. Zero reasoning — report raw facts only.
+
+## Capabilities
+
+1. **Navigate URLs** — load pages, report HTTP status codes
+2. **Read page content** — extract titles, visible text, DOM element lists
+3. **Take screenshots** — via Playwright MCP or screenshot tools
+4. **Health checks** — execute curl with retries, report response codes
+5. **Element inventory** — list buttons, links, forms, tables on a page
+
+## Output Schema
+
+Always return structured JSON:
+
+```json
+{
+  "url": "https://example.com/page",
+  "status": 200,
+  "title": "Page Title",
+  "elements": [
+    {"type": "button", "text": "Submit", "selector": "#submit-btn"},
+    {"type": "table", "columns": ["Name", "Date", "Status"], "row_count": 25},
+    {"type": "form", "fields": ["name", "email", "phone"]}
+  ],
+  "visible_text_summary": "First 500 chars of visible page text...",
+  "errors": []
+}
+```
+
+## Health Check Pattern
+
+```bash
+URL="$1"
+MAX_RETRIES=3
+RETRY_DELAY=2
+
+for i in $(seq 1 $MAX_RETRIES); do
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null || echo "000")
+  if [ "$HTTP_CODE" != "000" ]; then
+    echo "{\"url\": \"$URL\", \"status\": $HTTP_CODE, \"attempt\": $i}"
+    break
+  fi
+  sleep $RETRY_DELAY
+done
+```
+
+## Rules
+
+- **NEVER** analyze or interpret findings — just report raw observations
+- **NEVER** classify severity or importance of anything observed
+- **NEVER** suggest fixes or improvements
+- **ALWAYS** return structured JSON matching the schema above
+- **ALWAYS** report errors in the `errors` array, never as free text
+- If a page fails to load, report `"status": 0` with the error in `errors[]`

--- a/plugins/browser-test-router/agents/test-analyst.md
+++ b/plugins/browser-test-router/agents/test-analyst.md
@@ -1,0 +1,59 @@
+---
+name: test-analyst
+description: Analyze test results, classify gaps by severity, draft implementation issues. For standalone use — main session analysis runs inline as Opus.
+tools: Read, Write, Bash
+model: opus
+color: magenta
+---
+
+# Test Analyst
+
+Analysis agent for gap classification, severity assessment, and issue drafting. Requires deep judgment and architectural reasoning.
+
+**Note**: When using the browser-test-orchestration skill, the main session already runs as Opus. Analysis happens inline — no agent spawn needed. This agent exists for:
+- Standalone use outside the orchestration workflow
+- Reference documentation for the delegation pattern
+- Cases where analysis needs to run as a separate Task
+
+## Capabilities
+
+1. **Gap classification** — categorize discrepancies by type and severity
+2. **Severity assessment** — apply Nielsen severity scale (0-4) with justification
+3. **Issue drafting** — create implementation-ready issue documents
+4. **Spec interpretation** — parse module specifications to extract test criteria
+5. **Permission strategy** — design role-based access control test plans
+
+## Input
+
+Receives comparison results from page-comparator and/or raw observations from page-navigator and form-operator.
+
+## Analysis Protocol
+
+1. **Review all differences** from comparison results
+2. **Cross-reference with spec** — is this expected behavior or a gap?
+3. **Classify each gap**:
+   - Category: Feature, Data, Logic, Permission, Validation, CRUD, UI, OutOfScope
+   - Severity: 0 (Not a problem) through 4 (Catastrophe)
+4. **Draft issues** for gaps with severity >= 1, including:
+   - Reproduction steps
+   - Expected vs actual behavior
+   - Implementation requirements (backend endpoints, frontend components, business rules)
+   - Test criteria for verification
+
+## Severity Scale (Nielsen)
+
+| Severity | Level | Definition |
+|----------|-------|------------|
+| 4 | Catastrophe | System unusable, data loss risk |
+| 3 | Major | Feature broken, no workaround |
+| 2 | Minor | Issue with workaround available |
+| 1 | Cosmetic | Minor UI/UX issue |
+| 0 | Not a problem | Not a usability issue |
+
+## Rules
+
+- **ALWAYS** justify severity with concrete reasoning
+- **ALWAYS** include implementation requirements for Missing Feature issues
+- **ALWAYS** reference the specific spec section that defines the requirement
+- **NEVER** create issues for out-of-scope features
+- **NEVER** inflate severity — a cosmetic issue is severity 1, not 3

--- a/plugins/browser-test-router/commands/browser-test.md
+++ b/plugins/browser-test-router/commands/browser-test.md
@@ -1,0 +1,35 @@
+---
+allowed-tools: Bash, Read, WebFetch, Task
+description: Run browser testing with multi-model delegation for token efficiency
+argument-hint: "[url_or_module] (optional - URL to test or module name)"
+---
+
+# /browser-test-router:browser-test
+
+Activate the browser-test-orchestration skill with multi-model delegation.
+
+## What to do
+
+1. **Load the orchestration skill** from this plugin's `skills/browser-test-orchestration/SKILL.md`
+
+2. **Determine target**:
+   - If `$ARGUMENTS` contains a URL → single-page test mode
+   - If `$ARGUMENTS` contains a module name → module test mode (requires acceptance-test skill)
+   - If no arguments → prompt user for target
+
+3. **Single-page test mode** (URL provided):
+   - Delegate navigation to Haiku: `Task(model:"haiku", prompt:"Navigate to {url}, report status/title/elements as JSON")`
+   - Review results inline as Opus
+   - If a second URL is provided for comparison, delegate both navigations to Haiku, then comparison to Sonnet
+
+4. **Module test mode** (module name provided):
+   - Activate the project's acceptance-test skill with model routing enabled
+   - Follow the delegation protocol from the orchestration skill
+
+5. **Report model usage** at the end:
+   ```
+   Model Usage:
+   - Haiku:  {N} calls ({description})
+   - Sonnet: {M} calls ({description})
+   - Opus:   inline (analysis, classification)
+   ```

--- a/plugins/browser-test-router/hooks/hooks.json
+++ b/plugins/browser-test-router/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Check if the Bash command about to be executed is a curl health check, URL navigation, or browser automation command (curl, wget, playwright). If it is, output EXACTLY: '[browser-test-router] Consider delegating mechanical browser work to Haiku via Task(model:\"haiku\") for token savings. Run /browser-test-router:browser-test for the full delegation workflow.' If the command is not browser-related, output nothing."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/browser-test-router/skills/browser-test-orchestration/SKILL.md
+++ b/plugins/browser-test-router/skills/browser-test-orchestration/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: browser-test-orchestration
+description: Multi-model delegation protocol for browser testing — Haiku for mechanics, Sonnet for comparison, Opus for analysis
+---
+
+# Browser Test Orchestration
+
+Delegation protocol that routes browser testing work to the cheapest capable model. Opus orchestrates, Haiku executes mechanical operations, Sonnet compares pages.
+
+**Token savings**: 45-60% reduction on browser-heavy testing sessions by offloading zero-reasoning work to Haiku (15x cheaper) and moderate-reasoning work to Sonnet (5x cheaper).
+
+---
+
+## Model Routing Table
+
+| Task | Model | Why | Delegation |
+|------|-------|-----|------------|
+| URL navigation, health checks | Haiku | Mechanical, zero reasoning, 15x cheaper | `Task(model:"haiku")` |
+| Screenshots, element inventory | Haiku | Observation only, no judgment needed | `Task(model:"haiku")` |
+| Form filling, button clicking | Haiku | Mechanical input, zero reasoning | `Task(model:"haiku")` |
+| Login/logout session management | Haiku | Mechanical credential entry | `Task(model:"haiku")` |
+| Side-by-side page comparison | Sonnet | Moderate reasoning for structural alignment, 5x cheaper | `Task(model:"sonnet")` |
+| Spec parsing, test criteria extraction | Opus | Complex comprehension | Inline (main session) |
+| Gap classification, severity assessment | Opus | Deep judgment needed | Inline (main session) |
+| Issue drafting with implementation reqs | Opus | Architectural reasoning | Inline (main session) |
+| Permission testing strategy | Opus | Security reasoning | Inline (main session) |
+| Cost tracking, session summary | Opus | Synthesis | Inline (main session) |
+
+---
+
+## Delegation Protocol
+
+### Navigation Delegation
+
+When you need to navigate to a URL and observe the page:
+
+```
+Task(model:"haiku", subagent_type:"general-purpose", prompt:"
+Navigate to {url}.
+Report as JSON: {url, status, title, elements[], visible_text_summary, errors[]}
+- elements: list every button, link, form, and table with text/selector
+- visible_text_summary: first 500 chars of visible text
+- errors: any load errors, missing resources, console errors
+Do NOT analyze or interpret — just report raw observations.
+")
+```
+
+### Form Operation Delegation
+
+When you need to fill a form or click buttons:
+
+```
+Task(model:"haiku", subagent_type:"general-purpose", prompt:"
+On {url}:
+1. {action_description}
+2. Fill fields: {field_name}={value}, {field_name}={value}
+3. Click '{button_text}'
+Report as JSON: {action, url, fields_filled[], response_code, messages[], errors[], page_state_after}
+Do NOT judge whether the response is correct — just report what happened.
+")
+```
+
+### Comparison Delegation
+
+When you have two page snapshots to compare:
+
+```
+Task(model:"sonnet", subagent_type:"general-purpose", prompt:"
+Compare these two page snapshots:
+
+LEGACY (source of truth):
+{legacy_snapshot_json}
+
+NEW (being tested):
+{new_snapshot_json}
+
+Report as JSON: {legacy_url, new_url, matches[], differences[], legacy_only[], new_only[], summary}
+- differences: include severity_hint (high/medium/low) but NOT final classification
+- Compare: data values, columns, record counts, sorting, buttons, filters
+Do NOT create issues or recommend actions — just report structural differences.
+")
+```
+
+---
+
+## Parallel Navigation Pattern
+
+When testing two systems side-by-side, navigate both in parallel:
+
+```
+# TWO PARALLEL Task calls — both model:"haiku"
+
+Task 1: Task(model:"haiku", prompt:"Navigate to {legacy_url}. Report JSON: {url, status, title, elements[], visible_text_summary, errors[]}")
+
+Task 2: Task(model:"haiku", prompt:"Navigate to {new_url}. Report JSON: {url, status, title, elements[], visible_text_summary, errors[]}")
+
+# THEN one Task call — model:"sonnet"
+
+Task 3: Task(model:"sonnet", prompt:"Compare snapshots: {task1_result} vs {task2_result}. Report structured diff as JSON.")
+
+# THEN inline Opus analysis of the comparison results
+```
+
+This pattern mirrors tribunal-review's parallel Bash execution — two independent operations run simultaneously, then results are synthesized.
+
+---
+
+## CRUD Testing Delegation
+
+For each entity's CRUD lifecycle, split mechanical vs analytical work:
+
+### CREATE Test
+
+1. **Opus inline**: Design test data from spec (field values, constraints to test)
+2. **Haiku Task**: Navigate to create form, inventory fields
+   ```
+   Task(model:"haiku", prompt:"Navigate to {create_url}. List all form fields as JSON: {fields[{name, type, required, current_value}]}")
+   ```
+3. **Haiku Task**: Fill form with test data, submit
+   ```
+   Task(model:"haiku", prompt:"On {create_url}, fill: {field1}={val1}, {field2}={val2}. Click '{submit_button}'. Report: {action, fields_filled[], response_code, messages[], errors[]}")
+   ```
+4. **Opus inline**: Evaluate response — was creation successful? Does it match spec expectations?
+
+### READ Test
+
+1. **Opus inline**: Identify columns, filters, sort expectations from spec
+2. **Two parallel Haiku Tasks**: Navigate to list page in both systems
+3. **Sonnet Task**: Compare the two list pages (columns, record count, data values)
+4. **Opus inline**: Classify differences, assess severity
+
+### UPDATE Test
+
+1. **Opus inline**: Choose record and field to modify from spec
+2. **Haiku Task**: Navigate to edit form, modify field, submit
+3. **Haiku Task**: Navigate back to verify change persisted
+4. **Opus inline**: Evaluate — did update work correctly?
+
+### DELETE Test
+
+1. **Opus inline**: Identify delete rules from spec (cascade, soft-delete, restrictions)
+2. **Haiku Task**: Find and click delete button, report confirmation dialog
+3. **Haiku Task**: Confirm or cancel delete, report result
+4. **Opus inline**: Evaluate against spec rules
+
+---
+
+## Business Rule Testing Delegation
+
+For each numbered rule in the spec:
+
+1. **Opus inline**: Parse rule, design positive and negative test cases
+2. **Haiku Task**: Execute positive test (violate rule → expect error)
+   ```
+   Task(model:"haiku", prompt:"On {url}, enter {invalid_data} that violates: '{rule_text}'. Submit. Report: {response_code, messages[], errors[]}")
+   ```
+3. **Haiku Task**: Execute negative test (valid input → expect success)
+   ```
+   Task(model:"haiku", prompt:"On {url}, enter {valid_data}. Submit. Report: {response_code, messages[], errors[]}")
+   ```
+4. **Opus inline**: Classify — ENFORCED / NOT ENFORCED / PARTIALLY ENFORCED
+
+---
+
+## Validation Rule Testing Delegation
+
+For each field/rule row in the spec's validation table:
+
+1. **Opus inline**: Determine invalid input for the rule type
+2. **Haiku Task**: Enter invalid input, submit, report response
+   ```
+   Task(model:"haiku", prompt:"On {form_url}, leave '{field}' empty (or enter '{invalid_value}'). Click submit. Report: {response_code, messages[], errors[], field_highlighted: bool}")
+   ```
+3. **Opus inline**: Compare reported message to spec's expected message, classify result
+
+---
+
+## Workflow Testing Delegation
+
+For each multi-step workflow in the spec:
+
+1. **Opus inline**: Parse all steps, prepare test data for the full sequence
+2. **Haiku Tasks** (sequential): Execute each mechanical step
+   ```
+   Step 1: Task(model:"haiku", prompt:"Navigate to {url}. Report page state.")
+   Step 2: Task(model:"haiku", prompt:"Click '{button}'. Report response.")
+   Step 3: Task(model:"haiku", prompt:"Fill {fields}. Submit. Report result.")
+   ...
+   ```
+3. **Opus inline**: Evaluate each step's result against spec, track workflow completeness
+
+---
+
+## Permission Testing Delegation
+
+For each permission level in the spec's matrix:
+
+1. **Opus inline**: Design positive/negative test cases per role
+2. **Haiku Task**: Log out current session
+3. **Haiku Task**: Log in as target test account
+4. **Haiku Task**: Navigate to restricted page, inventory visible elements
+5. **Opus inline**: Evaluate — correct elements visible/hidden for this role?
+
+---
+
+## Health Check Delegation
+
+Before testing begins, delegate service health checks to Haiku:
+
+```
+# Two parallel Haiku Tasks
+
+Task 1: Task(model:"haiku", prompt:"
+Run health check with retries:
+  URL: {legacy_url}
+  Max retries: 3, delay: 2s
+Report: {url, status, attempt, errors[]}
+")
+
+Task 2: Task(model:"haiku", prompt:"
+Run health check with retries:
+  URL: {new_url}
+  Also check: {backend_health_url}
+  Max retries: 6, delay: 5s
+Report: {url, status, attempt, errors[]}
+")
+```
+
+---
+
+## Cost Tracking
+
+After each testing session, report model usage breakdown:
+
+```
+## Model Usage Summary
+
+| Model | Calls | Purpose |
+|-------|-------|---------|
+| Haiku | {N} | Navigation ({a}), forms ({b}), health checks ({c}), login/logout ({d}) |
+| Sonnet | {M} | Page comparisons ({e}) |
+| Opus | inline | Spec parsing, gap classification, issue drafting, session orchestration |
+
+Estimated token savings: ~{X}% vs all-Opus execution
+- Haiku calls saved ~{Y} Opus tokens (navigation + form mechanics)
+- Sonnet calls saved ~{Z} Opus tokens (page comparisons)
+```
+
+---
+
+## What Stays Inline (Opus Only)
+
+These tasks require deep reasoning and MUST NOT be delegated:
+
+- Spec parsing and test criteria extraction
+- Test case design (choosing what to test, what data to use)
+- Gap classification and severity assessment
+- Issue drafting with implementation requirements
+- Permission testing strategy design
+- Session orchestration and decision-making
+- Final verdict on whether a feature is working or broken
+
+---
+
+## Integration with Project Skills
+
+This plugin provides the generic delegation pattern. Project-specific testing skills
+(like acceptance-test) reference this pattern and map their domain-specific variables:
+
+```
+# In project's acceptance-test skill:
+# "Navigate to legacy system" becomes:
+Task(model:"haiku", prompt:"Navigate to ${LEGACY_URL}/#${legacy_route}. Report JSON...")
+
+# "Navigate to new system" becomes:
+Task(model:"haiku", prompt:"Navigate to ${NEW_URL}/${new_route}. Report JSON...")
+
+# "Compare both systems" becomes:
+Task(model:"sonnet", prompt:"Compare: ${legacy_snapshot} vs ${new_snapshot}. Structured diff...")
+```
+
+Project skills map their specific URLs, routes, and test accounts to this generic protocol.

--- a/plugins/browser-test-router/skills/browser-test-orchestration/references/model-routing-guide.md
+++ b/plugins/browser-test-router/skills/browser-test-orchestration/references/model-routing-guide.md
@@ -1,0 +1,142 @@
+# Model Routing Guide
+
+Reference document for multi-model delegation in browser testing workflows.
+
+## The Problem
+
+Claude Max subscriptions deplete tokens quickly when Opus handles everything, including
+mechanical browser work that requires zero reasoning. Browser testing is particularly
+expensive because navigation, form filling, and screenshot capture generate large
+tool-use contexts that Opus processes at full cost.
+
+## The Solution: Model-Appropriate Routing
+
+Route each task to the cheapest model that can handle it correctly:
+
+```
+┌─────────────────────────────────────────────────┐
+│                 OPUS (Orchestrator)              │
+│  Spec parsing, test design, gap classification, │
+│  severity assessment, issue drafting             │
+│                                                  │
+│  ┌──────────────┐    ┌───────────────────────┐   │
+│  │ HAIKU Tasks  │    │   SONNET Tasks        │   │
+│  │              │    │                       │   │
+│  │ • Navigate   │    │ • Compare two pages   │   │
+│  │ • Screenshot │    │ • Structural diff     │   │
+│  │ • Fill forms │    │ • Severity hints      │   │
+│  │ • Click btns │    │                       │   │
+│  │ • Health chk │    │                       │   │
+│  │ • Login/out  │    │                       │   │
+│  └──────────────┘    └───────────────────────┘   │
+│                                                  │
+│  Results flow back to Opus for analysis          │
+└─────────────────────────────────────────────────┘
+```
+
+## Cost Comparison
+
+| Operation | Opus Cost | Delegated Cost | Savings |
+|-----------|-----------|----------------|---------|
+| Navigate URL, report elements | 1x | 0.07x (Haiku) | 93% |
+| Fill form, submit, report | 1x | 0.07x (Haiku) | 93% |
+| Health check with retries | 1x | 0.07x (Haiku) | 93% |
+| Compare two page snapshots | 1x | 0.20x (Sonnet) | 80% |
+| Analyze results, classify gaps | 1x | 1x (Opus inline) | 0% |
+
+## When to Delegate vs Stay Inline
+
+### Delegate to Haiku (mechanical, zero reasoning)
+
+- Loading a URL and reporting what's on the page
+- Filling form fields with provided values
+- Clicking buttons and reporting the response
+- Running curl commands and reporting status codes
+- Logging in/out with provided credentials
+- Taking screenshots
+- Listing DOM elements on a page
+
+### Delegate to Sonnet (moderate reasoning)
+
+- Comparing two page snapshots structurally
+- Identifying matching/different/missing elements between pages
+- Providing severity hints for differences
+- Aligning columns and data between different layouts
+
+### Keep as Opus inline (deep reasoning)
+
+- Reading and interpreting module specifications
+- Designing test cases and choosing test data
+- Classifying gaps by category and severity
+- Drafting implementation-ready issues
+- Making architectural judgments
+- Permission testing strategy
+- Deciding what to test next
+
+## Structured JSON Contract
+
+All delegated agents return structured JSON. This is critical for:
+
+1. **Predictable parsing** — Opus can reliably extract results
+2. **No wasted tokens** — agents don't produce analysis Opus will redo
+3. **Clean separation** — observations (Haiku/Sonnet) vs analysis (Opus)
+
+### page-navigator output
+```json
+{"url": "", "status": 0, "title": "", "elements": [], "visible_text_summary": "", "errors": []}
+```
+
+### form-operator output
+```json
+{"action": "", "url": "", "fields_filled": [], "response_code": 0, "messages": [], "errors": []}
+```
+
+### page-comparator output
+```json
+{"legacy_url": "", "new_url": "", "matches": [], "differences": [], "legacy_only": [], "new_only": [], "summary": {}}
+```
+
+## Parallel Execution Patterns
+
+### Pattern 1: Dual System Navigation
+```
+Task(haiku) → legacy page    ┐
+                              ├→ Task(sonnet) → comparison → Opus analysis
+Task(haiku) → new page       ┘
+```
+
+### Pattern 2: Sequential Form Operations
+```
+Task(haiku) → navigate → Task(haiku) → fill form → Task(haiku) → verify → Opus analysis
+```
+
+### Pattern 3: Permission Sweep
+```
+Task(haiku) → logout → Task(haiku) → login(role1) → Task(haiku) → check page → Opus classify
+Task(haiku) → logout → Task(haiku) → login(role2) → Task(haiku) → check page → Opus classify
+...
+```
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|-------------|----------------|------------------|
+| Haiku analyzes gaps | Haiku lacks judgment for severity | Haiku reports, Opus classifies |
+| Sonnet drafts issues | Issue drafting needs architectural context | Sonnet compares, Opus drafts |
+| Opus navigates URLs | 15x more expensive for zero-reasoning work | Delegate to Haiku |
+| Opus fills forms | Mechanical task, no reasoning needed | Delegate to Haiku |
+| Skipping delegation for "just one URL" | Adds up across a testing session | Always delegate mechanical work |
+
+## Session-Level Savings Estimate
+
+For a typical acceptance testing session on one module:
+
+| Phase | Operations | Without Routing | With Routing |
+|-------|-----------|-----------------|--------------|
+| Health checks | 3-5 curl calls | Opus | Haiku (93% saved) |
+| Navigation | 10-20 page loads | Opus | Haiku (93% saved) |
+| Form operations | 5-15 form fills | Opus | Haiku (93% saved) |
+| Page comparisons | 5-10 diffs | Opus | Sonnet (80% saved) |
+| Analysis & issues | 10-20 evaluations | Opus | Opus (0% saved) |
+
+**Estimated overall savings: 45-60%** of total token consumption.


### PR DESCRIPTION
## Summary

- Adds browser-test-router plugin with multi-model delegation pattern for browser testing
- Routes mechanical browser work (navigation, form filling, screenshots) to Haiku (15x cheaper)
- Routes page comparisons to Sonnet (5x cheaper), keeps analysis/classification on Opus inline
- Includes 4 agents (page-navigator, form-operator, page-comparator, test-analyst), orchestration skill, command, and advisory hook
- Registers plugin in marketplace under "testing" category

## Test plan

- [ ] Install plugin: `/install browser-test-router` in a test project
- [ ] Verify command loads: `/browser-test-router:browser-test`
- [ ] Test Haiku delegation: ask Claude to navigate a URL, verify Task call uses `model:"haiku"`
- [ ] Test Sonnet delegation: compare two pages, verify Task call uses `model:"sonnet"`
- [ ] Verify advisory hook fires on curl commands