### PR TITLE
feat: add signoff/review auto-commit support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,7 @@
     {
       "name": "saas-startup-team",
       "description": "SaaS startup simulation — business founder, tech founder, and growth hacker iterate via file-based handoffs using Agent Teams, with on-demand consultants (lawyer for compliance, UX tester for usability and accessibility), building the product, acquiring customers, and iterating with one-shot improvements",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "author": {
         "name": "Andre Paat"
       },

--- a/plugins/saas-startup-team/.claude-plugin/plugin.json
+++ b/plugins/saas-startup-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saas-startup-team",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "SaaS startup simulation — business founder, tech founder, and growth hacker iterate via file-based handoffs using Agent Teams, with on-demand consultants (lawyer for compliance, UX tester for usability and accessibility), building the product, acquiring customers, and iterating with one-shot improvements",
   "author": {
     "name": "Andre Paat"

--- a/plugins/saas-startup-team/scripts/auto-commit.sh
+++ b/plugins/saas-startup-team/scripts/auto-commit.sh
@@ -59,6 +59,10 @@ elif echo "$rel_path" | grep -qE '^\.startup/handoffs/[0-9]{3}-[a-z]+-to-[a-z]+\
 elif echo "$rel_path" | grep -qE '^\.startup/improvements/[0-9]{3}-implementation\.md$'; then
   imp_num=$(echo "$filename" | grep -oE '^[0-9]{3}')
   commit_msg="improve: implementation ${imp_num}"
+elif echo "$rel_path" | grep -qE '^\.startup/signoffs/.*\.md$'; then
+  commit_msg="signoff: ${filename%.md}"
+elif echo "$rel_path" | grep -qE '^\.startup/reviews/.*\.md$'; then
+  commit_msg="review: ${filename%.md}"
 else
   # Not a milestone file — skip
   exit 0
@@ -70,6 +74,8 @@ git add -A docs/ || true
 git add -A backend/ || true
 git add -A frontend/ || true
 git add -A CLAUDE.md || true
+git add -A .startup/signoffs/ || true
+git add -A .startup/reviews/ || true
 
 # Check if there's anything to commit
 if git diff --cached --quiet 2>/dev/null; then


### PR DESCRIPTION
## Summary
- Add `.startup/signoffs/` and `.startup/reviews/` path matching to auto-commit.sh
- Generates commit messages: `signoff: {name}` and `review: {name}`
- Stages signoff/review directories alongside existing docs/backend/frontend staging
- In production repos (where these dirs are gitignored), only accumulated code changes get committed; in tests, the files themselves get staged

## Test plan
- [x] K3b: auto-commit.sh has .startup/signoffs/ path filter
- [x] K3c: auto-commit.sh has .startup/reviews/ path filter
- [x] K11: signoff write creates commit
- [x] K11b: signoff commit message format matches "signoff: mvp-core"
- [x] K12: review write creates commit
- [x] K12b: review commit message format matches "review: iteration-1"