### PR TITLE
fix: repair broken secret detection grep pipes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,7 @@
     {
       "name": "saas-startup-team",
       "description": "SaaS startup simulation — business founder, tech founder, and growth hacker iterate via file-based handoffs using Agent Teams, with on-demand consultants (lawyer for compliance, UX tester for usability and accessibility), building the product, acquiring customers, and iterating with one-shot improvements",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "author": {
         "name": "Andre Paat"
       },

--- a/plugins/saas-startup-team/.claude-plugin/plugin.json
+++ b/plugins/saas-startup-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saas-startup-team",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "SaaS startup simulation — business founder, tech founder, and growth hacker iterate via file-based handoffs using Agent Teams, with on-demand consultants (lawyer for compliance, UX tester for usability and accessibility), building the product, acquiring customers, and iterating with one-shot improvements",
   "author": {
     "name": "Andre Paat"

--- a/plugins/saas-startup-team/scripts/check-handoff-secrets.sh
+++ b/plugins/saas-startup-team/scripts/check-handoff-secrets.sh
@@ -27,7 +27,7 @@ fi
 # Hardcoded env var assignments with actual values (KEY=value, not KEY=\$VAR or KEY=<placeholder>)
 # Match: ADMIN_API_KEY=test123, SECRET_KEY=abc123, etc.
 # Skip: KEY=${VAR}, KEY=<your-key>, KEY="", KEY=your_key_here, KEY=changeme
-if echo "$content" | grep -qE '(API_KEY|SECRET_KEY|PASSWORD|ACCESS_KEY)=[^$<"{][a-zA-Z0-9_-]{4,}' | grep -qvE '(changeme|your_|example|placeholder|xxx)' 2>/dev/null; then
+if echo "$content" | grep -E '(API_KEY|SECRET_KEY|PASSWORD|ACCESS_KEY)=[^$<"{][a-zA-Z0-9_-]{4,}' | grep -qvE '(changeme|your_|example|placeholder|xxx)' 2>/dev/null; then
   violations="${violations}Hardcoded credential assignment detected. "
 fi
 
@@ -37,7 +37,7 @@ if echo "$content" | grep -qE 'Authorization:\s*(Bearer|Basic)\s+[a-zA-Z0-9+/=_-
 fi
 
 # Curl commands with actual API key values in headers (not env var references like $API_KEY)
-if echo "$content" | grep -qE 'X-API-Key:\s*[a-zA-Z0-9_-]{8,}' | grep -qvE '\$' 2>/dev/null; then
+if echo "$content" | grep -E 'X-API-Key:\s*[a-zA-Z0-9_-]{8,}' | grep -qvE '\$' 2>/dev/null; then
   violations="${violations}Hardcoded API key in curl command. "
 fi
 


### PR DESCRIPTION
## Summary
- Fix two broken `grep -qE ... | grep -qvE ...` pipes in `check-handoff-secrets.sh` (lines 30, 40)
- `grep -q` suppresses stdout, so the second grep always receives empty input — two secret detection branches (hardcoded credential assignments, curl API key headers) silently never triggered
- Fix: remove `-q` from the first grep so matching lines flow to the second grep for exclusion filtering

## Test plan
- [x] Existing test suite passes (188/199 — same baseline, unrelated failures)
- [x] Manually verified: `ADMIN_API_KEY=superSecretKey123` now correctly blocked
- [x] Manually verified: `ADMIN_API_KEY=changeme` correctly allowed (placeholder)
- [x] Manually verified: `X-API-Key: mySecretKey` now correctly blocked
- [x] Manually verified: `X-API-Key: $API_KEY` correctly allowed (env var ref)