### PR TITLE
fix: update stale test expectations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,7 @@
     {
       "name": "saas-startup-team",
       "description": "SaaS startup simulation — business founder, tech founder, and growth hacker iterate via file-based handoffs using Agent Teams, with on-demand consultants (lawyer for compliance, UX tester for usability and accessibility), building the product, acquiring customers, and iterating with one-shot improvements",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "author": {
         "name": "Andre Paat"
       },

--- a/plugins/saas-startup-team/.claude-plugin/plugin.json
+++ b/plugins/saas-startup-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saas-startup-team",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "SaaS startup simulation — business founder, tech founder, and growth hacker iterate via file-based handoffs using Agent Teams, with on-demand consultants (lawyer for compliance, UX tester for usability and accessibility), building the product, acquiring customers, and iterating with one-shot improvements",
   "author": {
     "name": "Andre Paat"

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -436,7 +436,17 @@ test_plugin_config() {
   # E1-E4: plugin.json
   assert_json_valid "E1: plugin.json is valid JSON" "$PLUGIN_ROOT/.claude-plugin/plugin.json"
   assert_json_field "E2: plugin.json has name" "$PLUGIN_ROOT/.claude-plugin/plugin.json" ".name" "saas-startup-team"
-  assert_json_field "E3: plugin.json has version" "$PLUGIN_ROOT/.claude-plugin/plugin.json" ".version" "0.8.0"
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  local ver
+  ver=$(jq -r '.version' "$PLUGIN_ROOT/.claude-plugin/plugin.json" 2>/dev/null)
+  if [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "  ${GREEN}PASS${NC} E3: plugin.json version is valid semver ($ver)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} E3: plugin.json version is not valid semver ($ver)"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("E3: plugin.json version not valid semver: $ver")
+  fi
   local desc
   desc=$(jq -r '.description' "$PLUGIN_ROOT/.claude-plugin/plugin.json" 2>/dev/null)
   TOTAL_COUNT=$((TOTAL_COUNT + 1))
@@ -859,7 +869,7 @@ test_auto_commit_hook() {
   # K7: hooks.json PostToolUse has 2 entries
   local ptu_count
   ptu_count=$(jq '.hooks.PostToolUse | length' "$hooks_file" 2>/dev/null)
-  assert_equals "K7: PostToolUse has 6 entries" "$ptu_count" "6"
+  assert_equals "K7: PostToolUse has 11 entries" "$ptu_count" "11"
 
   # K8: Fourth PostToolUse entry references auto-commit.sh
   local fourth_cmd
@@ -876,7 +886,8 @@ test_auto_commit_hook() {
   (cd "$workdir" && git config user.email "test@test.com" && git config user.name "Test" && git commit --allow-empty -m "init" -q)
   mkdir -p "$workdir/.startup/handoffs"
   echo '{"iteration":1}' > "$workdir/.startup/state.json"
-  echo "test app code" > "$workdir/app.py"
+  mkdir -p "$workdir/backend"
+  echo "test app code" > "$workdir/backend/app.py"
   echo "handoff content" > "$workdir/.startup/handoffs/001-business-to-tech.md"
 
   ec=0; output=""
@@ -1059,12 +1070,12 @@ EOF
   # L10: hooks.json PostToolUse has 6 entries
   local ptu_count
   ptu_count=$(jq '.hooks.PostToolUse | length' "$hooks_file" 2>/dev/null)
-  assert_equals "L10: PostToolUse has 6 entries" "$ptu_count" "6"
+  assert_equals "L10: PostToolUse has 11 entries" "$ptu_count" "11"
 
   # L11: Fifth PostToolUse entry references enforce-tone.sh
-  local fifth_cmd
-  fifth_cmd=$(jq -r '.hooks.PostToolUse[4].hooks[0].command' "$hooks_file" 2>/dev/null)
-  assert_output_contains "L11: fifth PostToolUse references enforce-tone.sh" "$fifth_cmd" "enforce-tone.sh"
+  local sixth_cmd
+  sixth_cmd=$(jq -r '.hooks.PostToolUse[5].hooks[0].command' "$hooks_file" 2>/dev/null)
+  assert_output_contains "L11: sixth PostToolUse references enforce-tone.sh" "$sixth_cmd" "enforce-tone.sh"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- E3: replace hardcoded version (0.8.0) with semver format validation — stops breaking on every version bump
- K7, L10: update PostToolUse hook count from 6 to 11 (5 hooks were added since tests were written)
- K10: move test file from root `app.py` to `backend/app.py` — auto-commit.sh stages backend/, not root
- L11: update enforce-tone.sh index from [4] to [5] after hooks were inserted before it

## Test plan
- [x] E3: version validation passes
- [x] K7: PostToolUse count matches 11
- [x] K10: handoff auto-commit creates commit (file now in backend/)
- [x] L10: PostToolUse count matches 11
- [x] L11: sixth PostToolUse correctly references enforce-tone.sh