### PR TITLE
saas-startup-team: enforce handoff naming + migration (#21)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,7 @@
     {
       "name": "saas-startup-team",
       "description": "SaaS startup simulation — business founder, tech founder, and growth hacker iterate via file-based handoffs using Agent Teams, with on-demand consultants (lawyer for compliance, UX tester for usability and accessibility), building the product, acquiring customers, and iterating with one-shot improvements",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "author": {
         "name": "Andre Paat"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,7 @@
     {
       "name": "saas-startup-team",
       "description": "SaaS startup simulation — business founder, tech founder, and growth hacker iterate via file-based handoffs using Agent Teams, with on-demand consultants (lawyer for compliance, UX tester for usability and accessibility), building the product, acquiring customers, and iterating with one-shot improvements",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "author": {
         "name": "Andre Paat"
       },

--- a/plugins/saas-startup-team/.claude-plugin/plugin.json
+++ b/plugins/saas-startup-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saas-startup-team",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "SaaS startup simulation — business founder, tech founder, and growth hacker iterate via file-based handoffs using Agent Teams, with on-demand consultants (lawyer for compliance, UX tester for usability and accessibility), building the product, acquiring customers, and iterating with one-shot improvements",
   "author": {
     "name": "Andre Paat"

--- a/plugins/saas-startup-team/.claude-plugin/plugin.json
+++ b/plugins/saas-startup-team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "saas-startup-team",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "SaaS startup simulation — business founder, tech founder, and growth hacker iterate via file-based handoffs using Agent Teams, with on-demand consultants (lawyer for compliance, UX tester for usability and accessibility), building the product, acquiring customers, and iterating with one-shot improvements",
   "author": {
     "name": "Andre Paat"

--- a/plugins/saas-startup-team/docs/superpowers/plans/2026-04-24-handoff-naming-enforcement.md
+++ b/plugins/saas-startup-team/docs/superpowers/plans/2026-04-24-handoff-naming-enforcement.md
@@ -1,0 +1,1215 @@
+# Handoff Naming Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce the canonical `NNN-<direction>.md` handoff filename convention in `saas-startup-team` via a PreToolUse Write hook, and clean up existing non-conforming files in the reference project (aruannik) via a one-time migration script.
+
+**Architecture:** Two independent bash scripts added to the plugin — no changes to existing scripts or command flows. `enforce-handoff-naming.sh` runs as a PreToolUse hook on Write events and blocks non-conforming filenames with a helpful error message. `migrate-handoff-names.sh` is a standalone manual tool that dry-runs by default and moves misrouted content (signoffs, reviews, binaries) to their proper `.startup/` subdirectories while renaming residual topic-slug handoffs to the canonical `NNN-<direction>.md` form.
+
+**Tech Stack:** bash 4+, `jq`, `awk`, `sed`, `grep`, POSIX tools. No new dependencies.
+
+**Spec:** `plugins/saas-startup-team/docs/superpowers/specs/2026-04-24-handoff-naming-enforcement-design.md`
+
+---
+
+## Task 1: Version bump
+
+**Files:**
+- Modify: `plugins/saas-startup-team/.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+
+Prerequisite per repo CLAUDE.md: both files must stay in sync before push.
+
+- [ ] **Step 1: Bump `plugin.json`**
+
+Edit `plugins/saas-startup-team/.claude-plugin/plugin.json`, change `"version": "0.32.0"` to `"version": "0.33.0"`.
+
+- [ ] **Step 2: Bump `marketplace.json`**
+
+Edit the `saas-startup-team` entry's `"version": "0.32.0"` to `"version": "0.33.0"` in root `.claude-plugin/marketplace.json`.
+
+- [ ] **Step 3: Verify sync**
+
+Run: `grep -A1 '"saas-startup-team"' .claude-plugin/marketplace.json | grep version && jq -r .version plugins/saas-startup-team/.claude-plugin/plugin.json`
+Expected: both output `0.33.0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/saas-startup-team/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+git commit -m "chore(saas-startup-team): bump to 0.33.0 for handoff naming enforcement (#21)"
+```
+
+---
+
+## Task 2: Enforcement hook script
+
+**Files:**
+- Create: `plugins/saas-startup-team/scripts/enforce-handoff-naming.sh`
+- Test: `plugins/saas-startup-team/tests/run-tests.sh` (new `test_enforce_handoff_naming_hook` function)
+
+- [ ] **Step 1: Write the test function**
+
+Append this to `plugins/saas-startup-team/tests/run-tests.sh` just before the closing `}` of `test_index_handoff_hook` (end of Suite Q), or add as a new "Suite R" block after it. Insert **before** the `main()` function (which is around line 1879):
+
+```bash
+# ---------------------------------------------------------------------------
+# Suite R: Enforce Handoff Naming Hook (enforce-handoff-naming.sh)
+# ---------------------------------------------------------------------------
+
+test_enforce_handoff_naming_hook() {
+  echo -e "\n${CYAN}Suite R: enforce-handoff-naming.sh${NC}"
+  local script="$PLUGIN_ROOT/scripts/enforce-handoff-naming.sh"
+  local workdir ec output
+
+  # R1: script exists and is executable
+  assert_file_exists "R1: enforce-handoff-naming.sh exists" "$script"
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if [ -x "$script" ]; then
+    echo -e "  ${GREEN}PASS${NC} R1b: script is executable"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} R1b: script is not executable"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("R1b: script is not executable")
+  fi
+
+  # R2: path outside .startup/handoffs/ passes
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/src/main.py"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R2: outside handoffs exits 0" "$ec" 0
+
+  # R3: INDEX.md passes
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/INDEX.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R3: INDEX.md exits 0" "$ec" 0
+
+  # R4: canonical business-to-tech passes
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/001-business-to-tech.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R4: canonical business-to-tech exits 0" "$ec" 0
+
+  # R5: canonical tech-to-business passes
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/042-tech-to-business.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R5: canonical tech-to-business exits 0" "$ec" 0
+
+  # R6: canonical business-to-growth passes
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/007-business-to-growth.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R6: canonical business-to-growth exits 0" "$ec" 0
+
+  # R7: slug-only filename is blocked
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"'"$workdir"'/.startup/handoffs/business-to-tech-foo.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R7: slug-only filename exits 2" "$ec" 2
+  assert_output_contains "R7b: block message mentions NNN" "$output" "NNN"
+  assert_output_contains "R7c: block message mentions next NNN 001" "$output" "001"
+  rm -rf "$workdir"
+
+  # R8: timestamp-prefixed filename is blocked
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/2026-04-16T074318Z-business-to-tech-improve-189.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R8: timestamp-prefix exits 2" "$ec" 2
+
+  # R9: non-.md (binary) is blocked
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/sample.pdf"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R9: .pdf exits 2" "$ec" 2
+  assert_output_contains "R9b: block message mentions attachments/" "$output" "attachments"
+
+  # R10: non-canonical direction NNN-business-to-team is blocked
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/476-business-to-team.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R10: non-canonical direction exits 2" "$ec" 2
+
+  # R11: next-NNN computation reflects actual max
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/012-business-to-tech.md"
+  touch "$workdir/.startup/handoffs/007-tech-to-business.md"
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"'"$workdir"'/.startup/handoffs/bogus.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R11: block with existing files exits 2" "$ec" 2
+  assert_output_contains "R11b: next NNN is 013" "$output" "013"
+  rm -rf "$workdir"
+
+  # R12: empty file_path in stdin passes (defensive)
+  ec=0
+  output=$(echo '{}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R12: empty input exits 0" "$ec" 0
+
+  # R13: signoffs/ path is not blocked (not a handoff path)
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/signoffs/roundtrip-001.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R13: signoffs/ path exits 0" "$ec" 0
+}
+```
+
+Also add the dispatch line to `main()` (after `test_index_handoff_hook`):
+
+```bash
+  test_enforce_handoff_naming_hook
+```
+
+- [ ] **Step 2: Run tests, expect the suite to fail**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: `Suite R` fails on R1 (script missing).
+
+- [ ] **Step 3: Create the hook script**
+
+Create `plugins/saas-startup-team/scripts/enforce-handoff-naming.sh`:
+
+```bash
+#!/bin/bash
+# enforce-handoff-naming.sh — PreToolUse hook for Write.
+# Blocks Writes under .startup/handoffs/ unless the filename is INDEX.md or
+# matches the canonical NNN-<direction>.md pattern. Exit 2 with systemMessage
+# on block; exit 0 otherwise (pass through).
+#
+# Input: JSON on stdin with tool_input.file_path
+# Exit 0: not a handoff path, or canonical name
+# Exit 2: blocked, systemMessage on stderr
+
+set -uo pipefail
+
+input=$(cat || true)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+[ -z "$file_path" ] && exit 0
+
+# Only act on writes under .startup/handoffs/
+case "$file_path" in
+  */.startup/handoffs/*) ;;
+  *) exit 0 ;;
+esac
+
+filename=$(basename "$file_path")
+[ "$filename" = "INDEX.md" ] && exit 0
+
+# Canonical format
+if [[ "$filename" =~ ^[0-9]{3}-(business-to-tech|tech-to-business|business-to-growth|growth-to-business)\.md$ ]]; then
+  exit 0
+fi
+
+# Compute next available NNN for the error message
+handoff_dir=$(dirname "$file_path")
+next_nnn="001"
+if [ -d "$handoff_dir" ]; then
+  max=$(ls "$handoff_dir" 2>/dev/null | grep -oE '^[0-9]{3}' | sort -n | tail -1 || true)
+  if [ -n "$max" ]; then
+    next_nnn=$(printf '%03d' $((10#$max + 1)))
+  fi
+fi
+
+msg="Handoff filename '${filename}' is not valid. Handoffs must be named NNN-<direction>.md where NNN is a zero-padded 3-digit number and <direction> is one of: business-to-tech, tech-to-business, business-to-growth, growth-to-business. Next available NNN: ${next_nnn}. Binaries (.pdf, .png) belong in .startup/attachments/; signoffs in .startup/signoffs/; reviews in .startup/reviews/."
+
+jq -n --arg msg "$msg" '{systemMessage: $msg}' >&2
+exit 2
+```
+
+- [ ] **Step 4: Make executable**
+
+```bash
+chmod +x plugins/saas-startup-team/scripts/enforce-handoff-naming.sh
+```
+
+- [ ] **Step 5: Run tests, expect Suite R to pass**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: all R1–R13 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/saas-startup-team/scripts/enforce-handoff-naming.sh plugins/saas-startup-team/tests/run-tests.sh
+git commit -m "feat(saas-startup-team): enforce-handoff-naming PreToolUse hook (#21)"
+```
+
+---
+
+## Task 3: Register hook in `hooks.json`
+
+**Files:**
+- Modify: `plugins/saas-startup-team/hooks/hooks.json`
+- Modify: `plugins/saas-startup-team/tests/run-tests.sh` (extend `test_plugin_config`)
+
+- [ ] **Step 1: Add assertion in plugin config test**
+
+Locate `test_plugin_config()` (around line 433). After the existing assertions for hook entries, add:
+
+```bash
+  # C-enforce: PreToolUse enforce-handoff-naming.sh is registered
+  local enforce_cmd
+  enforce_cmd=$(jq -r '.hooks.PreToolUse[]?.hooks[]?.command // empty' "$PLUGIN_ROOT/hooks/hooks.json" | grep -F "enforce-handoff-naming.sh" || true)
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if [ -n "$enforce_cmd" ]; then
+    echo -e "  ${GREEN}PASS${NC} C-enforce: PreToolUse hook registers enforce-handoff-naming.sh"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} C-enforce: PreToolUse hook does not register enforce-handoff-naming.sh"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("C-enforce: missing enforce-handoff-naming.sh in PreToolUse")
+  fi
+
+  # C-enforce-matcher: the entry uses matcher "Write"
+  local enforce_matcher
+  enforce_matcher=$(jq -r '.hooks.PreToolUse[]? | select(.hooks[]?.command | test("enforce-handoff-naming.sh")) | .matcher // empty' "$PLUGIN_ROOT/hooks/hooks.json")
+  assert_equals "C-enforce-matcher: matcher is Write" "$enforce_matcher" "Write"
+```
+
+- [ ] **Step 2: Run tests, expect C-enforce to fail**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: `C-enforce` FAIL.
+
+- [ ] **Step 3: Add the PreToolUse block**
+
+Edit `plugins/saas-startup-team/hooks/hooks.json`. Inside `"hooks": { ... }`, add a sibling key `"PreToolUse"` alongside the existing `"TeammateIdle"`, `"TaskCompleted"`, `"PostToolUse"`, `"Stop"` keys:
+
+```json
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/enforce-handoff-naming.sh",
+            "description": "Block non-conforming handoff filenames (NNN-<direction>.md only)"
+          }
+        ]
+      }
+    ],
+```
+
+Exact insertion: add this block directly after the opening `"hooks": {` brace on line 2 and before `"TeammateIdle": [`. Keep comma placement valid.
+
+- [ ] **Step 4: Validate JSON**
+
+Run: `jq empty plugins/saas-startup-team/hooks/hooks.json`
+Expected: no output, exit 0.
+
+- [ ] **Step 5: Run tests, expect C-enforce to pass**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: all C-enforce assertions PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/saas-startup-team/hooks/hooks.json plugins/saas-startup-team/tests/run-tests.sh
+git commit -m "feat(saas-startup-team): register PreToolUse enforce-handoff-naming hook (#21)"
+```
+
+---
+
+## Task 4: Migration script skeleton
+
+**Files:**
+- Create: `plugins/saas-startup-team/scripts/migrate-handoff-names.sh`
+- Modify: `plugins/saas-startup-team/tests/run-tests.sh` (new `test_migrate_handoff_names` function)
+
+Skeleton: argument parsing (`--apply` flag), handoff dir resolution (arg or git root), dry-run default, canonical-skip logic, empty summary output.
+
+- [ ] **Step 1: Write the initial test function**
+
+Append to `plugins/saas-startup-team/tests/run-tests.sh` before `main()`:
+
+```bash
+# ---------------------------------------------------------------------------
+# Suite S: Migrate Handoff Names (migrate-handoff-names.sh)
+# ---------------------------------------------------------------------------
+
+test_migrate_handoff_names() {
+  echo -e "\n${CYAN}Suite S: migrate-handoff-names.sh${NC}"
+  local script="$PLUGIN_ROOT/scripts/migrate-handoff-names.sh"
+  local workdir ec output
+
+  # S1: script exists and is executable
+  assert_file_exists "S1: migrate-handoff-names.sh exists" "$script"
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if [ -x "$script" ]; then
+    echo -e "  ${GREEN}PASS${NC} S1b: script is executable"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} S1b: script is not executable"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("S1b: script is not executable")
+  fi
+
+  # S2: dry-run on empty dir returns 0 with summary
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S2: empty dir dry-run exits 0" "$ec" 0
+  assert_output_contains "S2b: output says dry-run" "$output" "Dry-run"
+  assert_output_contains "S2c: summary line present" "$output" "Summary:"
+  rm -rf "$workdir"
+
+  # S3: canonical-only dir — nothing to change
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/001-business-to-tech.md"
+  touch "$workdir/.startup/handoffs/002-tech-to-business.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S3: canonical-only exits 0" "$ec" 0
+  assert_output_contains "S3b: skip count is 2" "$output" "Skipping (already canonical): 2"
+  rm -rf "$workdir"
+}
+```
+
+Add dispatch in `main()` after `test_enforce_handoff_naming_hook`:
+
+```bash
+  test_migrate_handoff_names
+```
+
+- [ ] **Step 2: Run tests, expect Suite S to fail**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: S1 FAIL (script missing).
+
+- [ ] **Step 3: Create the migration script skeleton**
+
+Create `plugins/saas-startup-team/scripts/migrate-handoff-names.sh`:
+
+```bash
+#!/bin/bash
+# migrate-handoff-names.sh — one-time cleanup of .startup/handoffs/ to enforce
+# the canonical NNN-<direction>.md filename convention.
+#
+# Moves misplaced signoffs to .startup/signoffs/, reviews to .startup/reviews/,
+# binaries and directories to .startup/attachments/, and renames residual
+# topic-slug handoffs to NNN-<direction>.md with next-available numbers.
+#
+# Usage:
+#   bash migrate-handoff-names.sh                  # dry-run against git root
+#   bash migrate-handoff-names.sh --apply          # execute
+#   bash migrate-handoff-names.sh <handoff-dir>    # dry-run on explicit dir
+#   bash migrate-handoff-names.sh --apply <dir>    # execute on explicit dir
+
+set -uo pipefail
+
+APPLY=0
+HANDOFF_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) APPLY=1 ;;
+    -h|--help)
+      sed -n '2,13p' "$0"
+      exit 0 ;;
+    *) HANDOFF_DIR="$1" ;;
+  esac
+  shift
+done
+
+if [ -z "$HANDOFF_DIR" ]; then
+  GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not in a git repo and no dir argument supplied." >&2
+    exit 1
+  }
+  HANDOFF_DIR="$GIT_ROOT/.startup/handoffs"
+fi
+
+if [ ! -d "$HANDOFF_DIR" ]; then
+  echo "Handoff dir not found: $HANDOFF_DIR" >&2
+  exit 1
+fi
+
+STARTUP_DIR=$(dirname "$HANDOFF_DIR")
+SIGNOFFS_DIR="$STARTUP_DIR/signoffs"
+REVIEWS_DIR="$STARTUP_DIR/reviews"
+ATTACH_DIR="$STARTUP_DIR/attachments"
+
+CANONICAL_RE='^[0-9]{3}-(business-to-tech|tech-to-business|business-to-growth|growth-to-business)\.md$'
+
+# Buckets: arrays of "<source>|<dest>" strings
+SKIP_COUNT=0
+MOVE_SIGNOFFS=()
+MOVE_REVIEWS=()
+MOVE_ATTACH=()
+RENAMES=()
+MANUAL=()
+
+# --- Scan pass ---
+shopt -s nullglob dotglob
+for entry in "$HANDOFF_DIR"/*; do
+  [ "$(basename "$entry")" = "INDEX.md" ] && { SKIP_COUNT=$((SKIP_COUNT + 1)); continue; }
+  filename=$(basename "$entry")
+
+  if [[ "$filename" =~ $CANONICAL_RE ]] && [ -f "$entry" ]; then
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+    continue
+  fi
+
+  # Rules 2-5 will be added in later tasks. For now, anything non-canonical
+  # goes to MANUAL so the skeleton produces correct counts on mixed dirs.
+  MANUAL+=("${entry}|(rules not yet implemented)")
+done
+shopt -u nullglob dotglob
+
+# --- Output ---
+echo "=== Handoff migration plan for ${HANDOFF_DIR} ==="
+echo ""
+echo "Skipping (already canonical): ${SKIP_COUNT}"
+echo ""
+
+if [ "${#MANUAL[@]}" -gt 0 ]; then
+  echo "Manual review needed (${#MANUAL[@]} files, left in place):"
+  for item in "${MANUAL[@]}"; do
+    src="${item%%|*}"
+    reason="${item##*|}"
+    echo "  $(basename "$src")    (reason: ${reason})"
+  done
+  echo ""
+fi
+
+echo "Summary: skip ${SKIP_COUNT}, move $((${#MOVE_SIGNOFFS[@]} + ${#MOVE_REVIEWS[@]} + ${#MOVE_ATTACH[@]})), rename ${#RENAMES[@]}, manual ${#MANUAL[@]}"
+
+if [ "$APPLY" -eq 0 ]; then
+  echo "Dry-run — re-run with --apply to perform changes."
+fi
+```
+
+- [ ] **Step 4: Make executable**
+
+```bash
+chmod +x plugins/saas-startup-team/scripts/migrate-handoff-names.sh
+```
+
+- [ ] **Step 5: Run tests, expect Suite S to pass**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: S1–S3c PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/saas-startup-team/scripts/migrate-handoff-names.sh plugins/saas-startup-team/tests/run-tests.sh
+git commit -m "feat(saas-startup-team): migrate-handoff-names.sh skeleton (#21)"
+```
+
+---
+
+## Task 5: Migration — MOVE rules (signoffs, reviews, attachments)
+
+**Files:**
+- Modify: `plugins/saas-startup-team/scripts/migrate-handoff-names.sh`
+- Modify: `plugins/saas-startup-team/tests/run-tests.sh` (extend Suite S)
+
+Implements rules 2, 3, 4 from the spec.
+
+- [ ] **Step 1: Add tests for move rules**
+
+Append to `test_migrate_handoff_names()` function, after the S3 block:
+
+```bash
+  # S4: roundtrip-signoff moves to signoffs/
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/133-roundtrip-signoff.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S4: dry-run with signoff exits 0" "$ec" 0
+  assert_output_contains "S4b: plan moves to signoffs/" "$output" "Move to .startup/signoffs/"
+  assert_output_contains "S4c: plan lists 133-roundtrip-signoff" "$output" "133-roundtrip-signoff.md"
+  rm -rf "$workdir"
+
+  # S5: qa-review moves to reviews/
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/369-qa-review.md"
+  touch "$workdir/.startup/handoffs/business-to-tech-satisfaction-guarantee.lawyer.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S5: plan moves to reviews/" "$output" "Move to .startup/reviews/"
+  assert_output_contains "S5b: plan lists qa-review file" "$output" "369-qa-review.md"
+  assert_output_contains "S5c: .lawyer.md renamed to lawyer-*" "$output" "lawyer-business-to-tech-satisfaction-guarantee.md"
+  rm -rf "$workdir"
+
+  # S6: binary moves to attachments/
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/arve_fixed_logo_preview.pdf"
+  touch "$workdir/.startup/handoffs/arve_fixed_logo_preview.png"
+  mkdir -p "$workdir/.startup/handoffs/421-artifacts"
+  touch "$workdir/.startup/handoffs/421-artifacts/sample.pdf"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S6: plan moves to attachments/" "$output" "Move to .startup/attachments/"
+  assert_output_contains "S6b: plan lists pdf" "$output" "arve_fixed_logo_preview.pdf"
+  assert_output_contains "S6c: plan lists directory" "$output" "421-artifacts"
+  rm -rf "$workdir"
+```
+
+- [ ] **Step 2: Run tests, expect S4–S6 to fail**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: S4, S5, S6 FAIL (rules not implemented).
+
+- [ ] **Step 3: Replace the scan-pass loop with the full move logic**
+
+In `plugins/saas-startup-team/scripts/migrate-handoff-names.sh`, replace the existing scan-pass `for entry in "$HANDOFF_DIR"/*; do … done` block with:
+
+```bash
+shopt -s nullglob dotglob
+for entry in "$HANDOFF_DIR"/*; do
+  filename=$(basename "$entry")
+  [ "$filename" = "INDEX.md" ] && { SKIP_COUNT=$((SKIP_COUNT + 1)); continue; }
+
+  # Canonical file — skip
+  if [ -f "$entry" ] && [[ "$filename" =~ $CANONICAL_RE ]]; then
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+    continue
+  fi
+
+  # Rule 2: signoffs → .startup/signoffs/
+  case "$filename" in
+    *roundtrip-signoff*.md|*-signoff.md|signoff-*.md)
+      MOVE_SIGNOFFS+=("${entry}|${SIGNOFFS_DIR}/${filename}")
+      continue ;;
+  esac
+
+  # Rule 3: review artifacts → .startup/reviews/
+  # Match a range of review-like patterns. Rename .lawyer.md / .QA-PASS.md
+  # variants into cleaner names on the way out.
+  dest_name="$filename"
+  matched_review=0
+  case "$filename" in
+    *.lawyer.md)
+      base="${filename%.lawyer.md}"
+      dest_name="lawyer-${base}.md"
+      matched_review=1 ;;
+    *.QA-PASS.md)
+      base="${filename%.QA-PASS.md}"
+      dest_name="qa-pass-${base}.md"
+      matched_review=1 ;;
+    *-qa-review.md|*-qa-pass.md) matched_review=1 ;;
+    *-business-review*.md|business-review-*.md) matched_review=1 ;;
+    *-business-qa*.md|business-qa-*.md) matched_review=1 ;;
+    *-regression-tests-*.md|*-regression-results-*.md) matched_review=1 ;;
+    *ux-audit*.md|*ux-fixes*.md) matched_review=1 ;;
+    tribunal-*-to-tech*.md|*-tribunal-to-tech*.md|*-tribunal-review-to-tech*.md) matched_review=1 ;;
+    *-tech-review-fixes*.md|*-tech-fixes*.md) matched_review=1 ;;
+    *-business-verification*.md) matched_review=1 ;;
+  esac
+  if [ "$matched_review" = "1" ]; then
+    MOVE_REVIEWS+=("${entry}|${REVIEWS_DIR}/${dest_name}")
+    continue
+  fi
+
+  # Rule 4: non-.md or directory → .startup/attachments/
+  if [ -d "$entry" ]; then
+    MOVE_ATTACH+=("${entry}|${ATTACH_DIR}/${filename}")
+    continue
+  fi
+  case "$filename" in
+    *.md) ;;
+    *)
+      MOVE_ATTACH+=("${entry}|${ATTACH_DIR}/${filename}")
+      continue ;;
+  esac
+
+  # Fallthrough — leave unresolved for now; rules 5–6 added in later task
+  MANUAL+=("${entry}|(rules 5-6 not yet implemented)")
+done
+shopt -u nullglob dotglob
+```
+
+- [ ] **Step 4: Extend the output section to print the move plans**
+
+Replace the existing output section (from `echo "=== Handoff migration plan…"` through the Summary line) with:
+
+```bash
+echo "=== Handoff migration plan for ${HANDOFF_DIR} ==="
+echo ""
+echo "Skipping (already canonical): ${SKIP_COUNT}"
+echo ""
+
+print_move_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+  [ "${#items[@]}" -eq 0 ] && return
+  echo "${title} (${#items[@]} files):"
+  for item in "${items[@]}"; do
+    src="${item%%|*}"
+    dest="${item##*|}"
+    echo "  $(basename "$src") → ${dest}"
+  done
+  echo ""
+}
+
+print_move_section "Move to .startup/signoffs/" "${MOVE_SIGNOFFS[@]}"
+print_move_section "Move to .startup/reviews/" "${MOVE_REVIEWS[@]}"
+print_move_section "Move to .startup/attachments/" "${MOVE_ATTACH[@]}"
+
+if [ "${#RENAMES[@]}" -gt 0 ]; then
+  echo "Rename (${#RENAMES[@]} files):"
+  for item in "${RENAMES[@]}"; do
+    src="${item%%|*}"
+    dest="${item##*|}"
+    echo "  $(basename "$src") → $(basename "$dest")"
+  done
+  echo ""
+fi
+
+if [ "${#MANUAL[@]}" -gt 0 ]; then
+  echo "Manual review needed (${#MANUAL[@]} files, left in place):"
+  for item in "${MANUAL[@]}"; do
+    src="${item%%|*}"
+    reason="${item##*|}"
+    echo "  $(basename "$src")    (reason: ${reason})"
+  done
+  echo ""
+fi
+
+echo "Summary: skip ${SKIP_COUNT}, move $((${#MOVE_SIGNOFFS[@]} + ${#MOVE_REVIEWS[@]} + ${#MOVE_ATTACH[@]})), rename ${#RENAMES[@]}, manual ${#MANUAL[@]}"
+
+if [ "$APPLY" -eq 0 ]; then
+  echo "Dry-run — re-run with --apply to perform changes."
+fi
+```
+
+- [ ] **Step 5: Run tests, expect S4–S6 to pass**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: S4, S5, S6 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/saas-startup-team/scripts/migrate-handoff-names.sh plugins/saas-startup-team/tests/run-tests.sh
+git commit -m "feat(saas-startup-team): migration move rules for signoffs/reviews/attachments (#21)"
+```
+
+---
+
+## Task 6: Migration — RENAME rule (canonical direction inference)
+
+**Files:**
+- Modify: `plugins/saas-startup-team/scripts/migrate-handoff-names.sh`
+- Modify: `plugins/saas-startup-team/tests/run-tests.sh` (extend Suite S)
+
+Implements rule 5 from the spec: frontmatter-first, filename-substring fallback; sequential NNN assignment from `max+1` sorted by mtime.
+
+- [ ] **Step 1: Add tests for rename**
+
+Append to `test_migrate_handoff_names()`:
+
+```bash
+  # S7: topic-slug renames to next-available NNN
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/012-business-to-tech.md"
+  # older slug file — should get NNN 013
+  touch -t 202603010000 "$workdir/.startup/handoffs/business-to-tech-foo.md"
+  # newer slug file — should get NNN 014
+  touch -t 202603020000 "$workdir/.startup/handoffs/tech-to-business-bar.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S7: rename section present" "$output" "Rename"
+  assert_output_contains "S7b: foo → 013-business-to-tech" "$output" "business-to-tech-foo.md → 013-business-to-tech.md"
+  assert_output_contains "S7c: bar → 014-tech-to-business" "$output" "tech-to-business-bar.md → 014-tech-to-business.md"
+  rm -rf "$workdir"
+
+  # S8: timestamp-prefix renames with canonical direction extracted
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/2026-04-16T074318Z-business-to-tech-improve-189.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S8: timestamp file renamed to business-to-tech" "$output" "2026-04-16T074318Z-business-to-tech-improve-189.md → 001-business-to-tech.md"
+  rm -rf "$workdir"
+
+  # S9: frontmatter wins over filename
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  cat > "$workdir/.startup/handoffs/business-to-tech-misnamed.md" <<'EOF'
+---
+from: tech-founder
+to: business-founder
+iteration: 3
+date: 2026-04-10
+type: implementation
+---
+
+## Summary
+Actually a tech-to-business handoff misnamed.
+EOF
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S9: frontmatter-derived direction wins" "$output" "business-to-tech-misnamed.md → 001-tech-to-business.md"
+  rm -rf "$workdir"
+```
+
+- [ ] **Step 2: Run tests, expect S7–S9 to fail**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: S7, S8, S9 FAIL.
+
+- [ ] **Step 3: Implement rename logic**
+
+In `plugins/saas-startup-team/scripts/migrate-handoff-names.sh`, add these helper functions near the top of the file (just after the `CANONICAL_RE=` line):
+
+```bash
+# Map frontmatter from:/to: pair to canonical direction, or empty if no match.
+infer_from_frontmatter() {
+  local file="$1"
+  local from to
+  from=$(awk '/^from:/ {gsub(/"/,"",$0); sub(/^from:[[:space:]]*/,""); print; exit}' "$file" 2>/dev/null | tr -d '[:space:]')
+  to=$(awk '/^to:/ {gsub(/"/,"",$0); sub(/^to:[[:space:]]*/,""); print; exit}' "$file" 2>/dev/null | tr -d '[:space:]')
+  case "${from}→${to}" in
+    business-founder→tech-founder) echo "business-to-tech" ;;
+    tech-founder→business-founder) echo "tech-to-business" ;;
+    business-founder→growth-hacker) echo "business-to-growth" ;;
+    growth-hacker→business-founder) echo "growth-to-business" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Map filename substring to canonical direction, or empty if none found.
+# Longest match first so "business-to-growth" isn't shadowed by "business".
+infer_from_filename() {
+  local filename="$1"
+  for d in business-to-growth growth-to-business business-to-tech tech-to-business; do
+    case "$filename" in
+      *"$d"*) echo "$d"; return ;;
+    esac
+  done
+  echo ""
+}
+
+# Compute the maximum NNN prefix in the handoff dir (0 if none).
+max_canonical_nnn() {
+  local dir="$1"
+  ls "$dir" 2>/dev/null | grep -oE '^[0-9]{3}' | sort -n | tail -1 || echo "0"
+}
+```
+
+Then, in the scan-pass loop, replace the fallthrough `MANUAL+=(...)` line with the rename logic. The full replacement for the inner loop body is:
+
+```bash
+  filename=$(basename "$entry")
+  [ "$filename" = "INDEX.md" ] && { SKIP_COUNT=$((SKIP_COUNT + 1)); continue; }
+
+  if [ -f "$entry" ] && [[ "$filename" =~ $CANONICAL_RE ]]; then
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+    continue
+  fi
+
+  # Rule 2: signoffs
+  case "$filename" in
+    *roundtrip-signoff*.md|*-signoff.md|signoff-*.md)
+      MOVE_SIGNOFFS+=("${entry}|${SIGNOFFS_DIR}/${filename}")
+      continue ;;
+  esac
+
+  # Rule 3: reviews (with .lawyer.md / .QA-PASS.md rename)
+  dest_name="$filename"
+  matched_review=0
+  case "$filename" in
+    *.lawyer.md)
+      base="${filename%.lawyer.md}"; dest_name="lawyer-${base}.md"; matched_review=1 ;;
+    *.QA-PASS.md)
+      base="${filename%.QA-PASS.md}"; dest_name="qa-pass-${base}.md"; matched_review=1 ;;
+    *-qa-review.md|*-qa-pass.md) matched_review=1 ;;
+    *-business-review*.md|business-review-*.md) matched_review=1 ;;
+    *-business-qa*.md|business-qa-*.md) matched_review=1 ;;
+    *-regression-tests-*.md|*-regression-results-*.md) matched_review=1 ;;
+    *ux-audit*.md|*ux-fixes*.md) matched_review=1 ;;
+    tribunal-*-to-tech*.md|*-tribunal-to-tech*.md|*-tribunal-review-to-tech*.md) matched_review=1 ;;
+    *-tech-review-fixes*.md|*-tech-fixes*.md) matched_review=1 ;;
+    *-business-verification*.md) matched_review=1 ;;
+  esac
+  if [ "$matched_review" = "1" ]; then
+    MOVE_REVIEWS+=("${entry}|${REVIEWS_DIR}/${dest_name}")
+    continue
+  fi
+
+  # Rule 4: binaries / directories → attachments
+  if [ -d "$entry" ]; then
+    MOVE_ATTACH+=("${entry}|${ATTACH_DIR}/${filename}")
+    continue
+  fi
+  case "$filename" in
+    *.md) ;;
+    *)
+      MOVE_ATTACH+=("${entry}|${ATTACH_DIR}/${filename}")
+      continue ;;
+  esac
+
+  # Rule 5: infer canonical direction
+  direction=$(infer_from_frontmatter "$entry")
+  if [ -z "$direction" ]; then
+    direction=$(infer_from_filename "$filename")
+  fi
+  if [ -n "$direction" ]; then
+    # Defer NNN assignment — collect into a rename candidate list with mtime
+    mtime=$(stat -c '%Y' "$entry" 2>/dev/null || stat -f '%m' "$entry" 2>/dev/null || echo 0)
+    RENAME_CANDIDATES+=("${mtime}|${entry}|${direction}")
+    continue
+  fi
+
+  # Rule 6: manual review
+  MANUAL+=("${entry}|no canonical direction in filename or frontmatter")
+```
+
+Add near the other array initializations:
+
+```bash
+RENAME_CANDIDATES=()
+```
+
+After the loop ends (before the Output section), add the NNN assignment pass:
+
+```bash
+# Assign NNNs to rename candidates in mtime order, starting at max+1.
+max_nnn=$(max_canonical_nnn "$HANDOFF_DIR")
+max_nnn=$((10#${max_nnn:-0}))
+if [ "${#RENAME_CANDIDATES[@]}" -gt 0 ]; then
+  # Sort by mtime (ascending)
+  IFS=$'\n' sorted=($(printf '%s\n' "${RENAME_CANDIDATES[@]}" | sort -t'|' -k1,1n))
+  unset IFS
+  for item in "${sorted[@]}"; do
+    src="${item#*|}"; src="${src%%|*}"          # middle field
+    direction="${item##*|}"
+    max_nnn=$((max_nnn + 1))
+    nnn=$(printf '%03d' "$max_nnn")
+    RENAMES+=("${src}|${HANDOFF_DIR}/${nnn}-${direction}.md")
+  done
+fi
+```
+
+- [ ] **Step 4: Run tests, expect S7–S9 to pass**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: S7, S8, S9 PASS. Earlier S1–S6 still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/saas-startup-team/scripts/migrate-handoff-names.sh plugins/saas-startup-team/tests/run-tests.sh
+git commit -m "feat(saas-startup-team): migration rename rule with NNN assignment (#21)"
+```
+
+---
+
+## Task 7: Migration — `--apply` execution and INDEX refresh
+
+**Files:**
+- Modify: `plugins/saas-startup-team/scripts/migrate-handoff-names.sh`
+- Modify: `plugins/saas-startup-team/tests/run-tests.sh` (extend Suite S)
+
+Implements the --apply path: create destination dirs, perform mv operations with collision handling, re-run `backfill-handoff-index.sh`.
+
+- [ ] **Step 1: Add tests for --apply**
+
+Append to `test_migrate_handoff_names()`:
+
+```bash
+  # S10: --apply performs moves and renames
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/001-business-to-tech.md"
+  touch "$workdir/.startup/handoffs/133-roundtrip-signoff.md"
+  touch "$workdir/.startup/handoffs/369-qa-review.md"
+  touch "$workdir/.startup/handoffs/arve.pdf"
+  touch "$workdir/.startup/handoffs/business-to-tech-foo.md"
+  ec=0
+  output=$(bash "$script" --apply "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S10: --apply exits 0" "$ec" 0
+  assert_file_exists "S10b: canonical preserved" "$workdir/.startup/handoffs/001-business-to-tech.md"
+  assert_file_exists "S10c: signoff moved" "$workdir/.startup/signoffs/133-roundtrip-signoff.md"
+  assert_file_exists "S10d: review moved" "$workdir/.startup/reviews/369-qa-review.md"
+  assert_file_exists "S10e: binary moved" "$workdir/.startup/attachments/arve.pdf"
+  assert_file_exists "S10f: slug renamed to 002-business-to-tech.md" "$workdir/.startup/handoffs/002-business-to-tech.md"
+  # Source filenames must no longer exist in handoffs/
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if [ ! -e "$workdir/.startup/handoffs/business-to-tech-foo.md" ]; then
+    echo -e "  ${GREEN}PASS${NC} S10g: source slug removed from handoffs/"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} S10g: source slug still in handoffs/"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("S10g: source slug not removed")
+  fi
+  assert_file_exists "S10h: INDEX.md regenerated" "$workdir/.startup/handoffs/INDEX.md"
+  rm -rf "$workdir"
+
+  # S11: --apply collision appends -dup suffix
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs" "$workdir/.startup/signoffs"
+  touch "$workdir/.startup/handoffs/133-roundtrip-signoff.md"
+  touch "$workdir/.startup/signoffs/133-roundtrip-signoff.md"  # pre-existing
+  ec=0
+  output=$(bash "$script" --apply "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S11: collision exits 0" "$ec" 0
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if ls "$workdir/.startup/signoffs/"*-dup* >/dev/null 2>&1; then
+    echo -e "  ${GREEN}PASS${NC} S11b: collision produces -dup file"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} S11b: no -dup file in signoffs/"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("S11b: no -dup file")
+  fi
+  rm -rf "$workdir"
+```
+
+- [ ] **Step 2: Run tests, expect S10–S11 to fail**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: S10, S11 FAIL (apply not implemented).
+
+- [ ] **Step 3: Implement --apply**
+
+In `plugins/saas-startup-team/scripts/migrate-handoff-names.sh`, insert this block AFTER the Output section (after the `Dry-run` message but before end of file):
+
+```bash
+# --- Apply pass ---
+if [ "$APPLY" -ne 1 ]; then
+  exit 0
+fi
+
+mkdir -p "$SIGNOFFS_DIR" "$REVIEWS_DIR" "$ATTACH_DIR"
+
+apply_move() {
+  local src="$1" dest="$2"
+  if [ -e "$dest" ]; then
+    local ts
+    ts=$(date +%Y%m%d%H%M%S)
+    local base="${dest%.*}"
+    local ext="${dest##*.}"
+    if [ "$base" = "$dest" ]; then
+      dest="${dest}-dup${ts}"
+    else
+      dest="${base}-dup${ts}.${ext}"
+    fi
+  fi
+  mv "$src" "$dest"
+}
+
+for item in "${MOVE_SIGNOFFS[@]}"; do apply_move "${item%%|*}" "${item##*|}"; done
+for item in "${MOVE_REVIEWS[@]}"; do apply_move "${item%%|*}" "${item##*|}"; done
+for item in "${MOVE_ATTACH[@]}"; do apply_move "${item%%|*}" "${item##*|}"; done
+for item in "${RENAMES[@]}"; do apply_move "${item%%|*}" "${item##*|}"; done
+
+echo ""
+echo "[DONE] Applied: ${#MOVE_SIGNOFFS[@]} signoffs, ${#MOVE_REVIEWS[@]} reviews, ${#MOVE_ATTACH[@]} attachments, ${#RENAMES[@]} renames."
+
+# Regenerate INDEX.md to reflect the new state
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -x "$SCRIPT_DIR/backfill-handoff-index.sh" ]; then
+  echo "Regenerating $HANDOFF_DIR/INDEX.md..."
+  bash "$SCRIPT_DIR/backfill-handoff-index.sh" "$HANDOFF_DIR"
+fi
+```
+
+Also: the existing dry-run footer `if [ "$APPLY" -eq 0 ]; then echo "Dry-run..."; fi` will already skip the `[DONE]` section, so no conflict.
+
+- [ ] **Step 4: Run tests, expect S10–S11 to pass**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: all Suite S tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/saas-startup-team/scripts/migrate-handoff-names.sh plugins/saas-startup-team/tests/run-tests.sh
+git commit -m "feat(saas-startup-team): migrate-handoff-names --apply + INDEX refresh (#21)"
+```
+
+---
+
+## Task 8: Documentation update
+
+**Files:**
+- Modify: `plugins/saas-startup-team/skills/startup-orchestration/references/handoff-protocol.md`
+
+- [ ] **Step 1: Append the Enforcement section**
+
+Open `plugins/saas-startup-team/skills/startup-orchestration/references/handoff-protocol.md`. After the existing "### Handoff Index (INDEX.md)" block (ends around line 86), before "## Handoff Validation Checklist" (line 87), insert:
+
+```markdown
+### Enforcement
+
+The canonical format is enforced by a PreToolUse hook (`enforce-handoff-naming.sh`).
+Writes to `.startup/handoffs/` that don't match `NNN-<direction>.md` with one of the four canonical directions are blocked with an error message that names the next available NNN.
+
+Misrouted content has dedicated homes:
+- Signoffs → `.startup/signoffs/`
+- Review artifacts (QA, lawyer, UX audit, tribunal, regression) → `.startup/reviews/`
+- Binaries and directories → `.startup/attachments/`
+
+For legacy projects with pre-existing non-conforming files, run the one-time migration script:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/migrate-handoff-names.sh          # dry-run, review the plan
+bash $CLAUDE_PLUGIN_ROOT/scripts/migrate-handoff-names.sh --apply  # execute
+```
+
+The migration moves misrouted content to the right subdirectory and renames residual topic-slug handoffs to `NNN-<direction>.md` with next-available numbers. Sort is by mtime so chronology is preserved.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugins/saas-startup-team/skills/startup-orchestration/references/handoff-protocol.md
+git commit -m "docs(saas-startup-team): document handoff naming enforcement + migration (#21)"
+```
+
+---
+
+## Task 9: Final test suite run
+
+- [ ] **Step 1: Run the full plugin test suite**
+
+Run: `bash plugins/saas-startup-team/tests/run-tests.sh`
+Expected: all suites A–S pass, no regressions.
+
+- [ ] **Step 2: If any regression, fix and re-run**
+
+If any previously-passing suite failed (e.g., a `test_plugin_config` assertion), correct and re-run. Do not proceed to aruannik validation until the suite is green.
+
+---
+
+## Task 10: Aruannik validation — dry-run
+
+**Files:** operates on `/mnt/data/ai/est-biz-aruannik/.startup/handoffs/`
+
+- [ ] **Step 1: Dry-run against aruannik**
+
+```bash
+bash /mnt/data/ai/claude-plugins/plugins/saas-startup-team/scripts/migrate-handoff-names.sh /mnt/data/ai/est-biz-aruannik/.startup/handoffs/ > /tmp/aruannik-migration-plan.txt
+```
+
+- [ ] **Step 2: Review the plan**
+
+```bash
+cat /tmp/aruannik-migration-plan.txt | less
+```
+
+Expected structure: a "Summary: …" line at the end with counts for skip/move/rename/manual. Check especially:
+- Move-to-signoffs count ≥ 35 (roundtrip-signoff + signoff files)
+- Move-to-reviews count ≥ 40 (qa-review + lawyer + ux-audit + regression etc.)
+- Move-to-attachments count ≥ 3 (pdf, png, 421-artifacts/)
+- Rename count ≥ 30 (topic-slug + timestamp)
+- Manual count small (investor-to-*, business-to-team, anything else unclassified)
+
+- [ ] **Step 3: Spot-check a few specific items**
+
+Verify the plan file contains:
+- `arve_fixed_logo_preview.pdf → /mnt/data/ai/est-biz-aruannik/.startup/attachments/arve_fixed_logo_preview.pdf`
+- `421-artifacts → /mnt/data/ai/est-biz-aruannik/.startup/attachments/421-artifacts`
+- `2026-04-16T074318Z-business-to-tech-improve-189.md → ` (some `NNN-business-to-tech.md`)
+- `business-to-tech-satisfaction-guarantee.lawyer.md → /mnt/data/ai/est-biz-aruannik/.startup/reviews/lawyer-business-to-tech-satisfaction-guarantee.md`
+- `205-investor-to-business.md    (reason: no canonical direction ...)` under Manual review
+
+If anything looks wrong (wrong section, missed rule), return to the relevant task and adjust before running --apply.
+
+- [ ] **Step 4: Pause and request user confirmation**
+
+If running under superpowers:subagent-driven-development / executing-plans, explicitly pause here and show the plan summary to the user. Do NOT run --apply without confirmation.
+
+---
+
+## Task 11: Aruannik validation — apply + verify
+
+- [ ] **Step 1: Apply the migration**
+
+```bash
+bash /mnt/data/ai/claude-plugins/plugins/saas-startup-team/scripts/migrate-handoff-names.sh --apply /mnt/data/ai/est-biz-aruannik/.startup/handoffs/ > /tmp/aruannik-migration-apply.txt
+```
+
+- [ ] **Step 2: Verify handoffs dir now contains only canonical + manual residue**
+
+```bash
+ls /mnt/data/ai/est-biz-aruannik/.startup/handoffs/ | grep -vE '^[0-9]{3}-(business-to-tech|tech-to-business|business-to-growth|growth-to-business)\.md$|^INDEX\.md$' > /tmp/aruannik-residue.txt
+wc -l /tmp/aruannik-residue.txt
+cat /tmp/aruannik-residue.txt
+```
+
+Expected: residue is only the "Manual review" files from Task 10 (investor-to-*, business-to-team-*, and anything else the script flagged). No signoffs, reviews, binaries, timestamp or topic-slug files.
+
+- [ ] **Step 3: Verify destination dirs populated**
+
+```bash
+ls /mnt/data/ai/est-biz-aruannik/.startup/signoffs/ | head -20
+ls /mnt/data/ai/est-biz-aruannik/.startup/reviews/ | head -20
+ls /mnt/data/ai/est-biz-aruannik/.startup/attachments/
+```
+
+Expected: signoffs/ contains `*-roundtrip-signoff.md` and `NNN-signoff.md`; reviews/ contains `*-qa-review.md`, `lawyer-*.md`, `ux-*`, etc.; attachments/ contains `arve_fixed_logo_preview.pdf`, `arve_fixed_logo_preview.png`, `421-artifacts/`.
+
+- [ ] **Step 4: Verify INDEX.md refreshed**
+
+```bash
+head -30 /mnt/data/ai/est-biz-aruannik/.startup/handoffs/INDEX.md
+grep -c '^---' /mnt/data/ai/est-biz-aruannik/.startup/handoffs/INDEX.md
+```
+
+Expected: header line, format line, then one entry per handoff now in the dir. Count of `---` rows (unnumbered entries) should be zero or match the manual-review residue count exactly.
+
+- [ ] **Step 5: Touch-test the hook**
+
+```bash
+echo '{"tool_input":{"file_path":"/mnt/data/ai/est-biz-aruannik/.startup/handoffs/garbage-name.md"}}' | bash /mnt/data/ai/claude-plugins/plugins/saas-startup-team/scripts/enforce-handoff-naming.sh
+echo "Exit: $?"
+```
+
+Expected: exit 2, stderr JSON with a `systemMessage` that says "Handoff filename 'garbage-name.md' is not valid." and names a concrete next NNN (the aruannik max + 1).
+
+---
+
+## Task 12: Final integration
+
+- [ ] **Step 1: Confirm clean working tree for plugin changes**
+
+Run: `git status`
+Expected: clean (all commits from prior tasks are in).
+
+- [ ] **Step 2: Verify commit list**
+
+Run: `git log --oneline main..HEAD`
+Expected sequence (approximate):
+- version bump
+- enforce-handoff-naming hook
+- PreToolUse registration
+- migration skeleton
+- migration move rules
+- migration rename rule
+- migration apply + INDEX refresh
+- docs update
+
+If the work was done directly on main (no feature branch), skip this check.
+
+- [ ] **Step 3: Push / open PR (user-triggered only)**
+
+Do NOT push unless explicitly asked. If asked:
+```bash
+git push origin HEAD
+```
+
+Then follow normal PR creation for this repo (see CLAUDE.md: `git config core.hooksPath .githooks` pre-push version-sync check will run).
+
+---
+
+## Self-Review (completed before writing this plan)
+
+**Spec coverage:**
+- [x] Enforcement hook → Task 2 + Task 3
+- [x] Migration script with all rules → Tasks 4, 5, 6, 7
+- [x] Documentation update → Task 8
+- [x] Version bump → Task 1
+- [x] Aruannik validation → Tasks 10, 11
+- [x] Tests for hook and migration → Tasks 2, 4, 5, 6, 7
+
+**Placeholder scan:** no TBDs/TODOs; every code step contains full code.
+
+**Type consistency:** canonical regex used identically in hook, migration, tests. Array variable names (`MOVE_SIGNOFFS`, `MOVE_REVIEWS`, `MOVE_ATTACH`, `RENAMES`, `RENAME_CANDIDATES`, `MANUAL`) used consistently. Destination path variables (`SIGNOFFS_DIR`, `REVIEWS_DIR`, `ATTACH_DIR`) consistent.

--- a/plugins/saas-startup-team/docs/superpowers/specs/2026-04-24-handoff-naming-enforcement-design.md
+++ b/plugins/saas-startup-team/docs/superpowers/specs/2026-04-24-handoff-naming-enforcement-design.md
@@ -1,0 +1,300 @@
+# Handoff Naming Enforcement — Design
+
+**Issue:** [#21 — saas-startup-team: enforce single handoff filename convention](https://github.com/paat/claude-plugins/issues/21)
+**Date:** 2026-04-24
+**Target version:** `saas-startup-team` 0.33.0
+
+## Problem
+
+`.startup/handoffs/` in long-running projects accumulates files under three coexisting naming schemes plus orphan roles and binaries. On the reference project (aruannik, 586 files), 135+ files do not match the canonical `NNN-<direction>.md` format documented in `handoff-protocol.md`. Non-conforming files silently bypass every downstream script:
+
+- `check-duplicate-handoff.sh` regex-matches only canonical names — duplicate detection skipped
+- `auto-commit.sh` only auto-commits canonical handoffs — non-conforming writes fall through
+- `status.sh` derives highest-handoff from canonical names only — count understated
+- `index-handoff.sh` indexes non-canonical files with `---` prefix — defeats numeric sort
+
+The documented convention is not enforced; drift has already happened and continues.
+
+## Scope (chosen approach: A + B from issue)
+
+1. **One-time migration script** to clean up existing non-conforming files per project.
+2. **PreToolUse hook** to block non-conforming Writes going forward.
+
+Explicitly **out of scope**:
+
+- No updates to `check-duplicate-handoff.sh`, `auto-commit.sh`, `status.sh`, `index-handoff.sh`. After migration + enforcement, they operate on a clean canonical set; existing fallbacks cover any residual legacy files.
+- No widening of the canonical 4-direction set. Organic roles (`investor-to-tech`, `business-to-team`, `tribunal-to-tech`, `ux-audit-*`) are handled by routing to `.startup/reviews/` or flagging for manual review, not by expanding the whitelist.
+- No changes to `/improve` or agent system prompts. The hook's error message is the teaching mechanism.
+
+## Canonical format (unchanged)
+
+```
+^[0-9]{3}-(business-to-tech|tech-to-business|business-to-growth|growth-to-business)\.md$
+```
+
+Plus `INDEX.md` (auto-generated).
+
+## Architecture
+
+Two independent additions, no changes to existing scripts:
+
+- `scripts/enforce-handoff-naming.sh` — new PreToolUse hook
+- `scripts/migrate-handoff-names.sh` — new standalone script (not a hook; run manually per project)
+
+Plus wiring:
+
+- `hooks/hooks.json` — one new PreToolUse entry
+- `skills/startup-orchestration/references/handoff-protocol.md` — short "Enforcement" section
+
+## Component 1 — `enforce-handoff-naming.sh`
+
+**Event:** `PreToolUse`
+**Matcher:** `Write` (not Edit — legacy files must remain editable for maintenance)
+**Exit codes:**
+- `0` — not a handoff path, or filename is valid
+- `2` — blocked; systemMessage on stderr
+
+### Algorithm
+
+```
+input = stdin JSON
+file_path = tool_input.file_path
+if file_path not under .startup/handoffs/: exit 0
+filename = basename(file_path)
+if filename == "INDEX.md": exit 0
+if filename matches canonical regex: exit 0
+
+# Block with helpful message
+handoff_dir = dirname(file_path)
+max_nnn = max of `^[0-9]{3}-` prefixes in handoff_dir (0 if none)
+next_nnn = printf '%03d' $((max_nnn + 1))
+systemMessage = "Handoff filename '<name>' is not valid. Handoffs must be named
+  NNN-<direction>.md where NNN is a zero-padded 3-digit number and <direction>
+  is one of: business-to-tech, tech-to-business, business-to-growth,
+  growth-to-business. Next available NNN: <next_nnn>. Binaries belong in
+  .startup/attachments/; signoffs in .startup/signoffs/; reviews in
+  .startup/reviews/."
+exit 2
+```
+
+### Why these design choices
+
+- **Write-only matcher:** Editing an existing legacy file (e.g., to correct frontmatter during migration) must not be blocked. Only net-new files need conformance.
+- **Computed `next_nnn` in the error:** Agents retry blocked Writes in their agent loop. Handing them the next valid NNN eliminates guesswork; prior hook patterns (`auto-commit.sh`, `check-duplicate-handoff.sh`) use the same pattern.
+- **PreToolUse, not PostToolUse:** Blocking is the goal; PostToolUse can't prevent the write.
+- **Routing hints in the message:** Most observed drift is misrouted content (signoffs/reviews/binaries landing in handoffs/). The error names the correct destination so the agent self-corrects.
+
+## Component 2 — `migrate-handoff-names.sh`
+
+**Invocation:** manual, per project. Dry-run by default; `--apply` performs the filesystem changes.
+
+**Signature:**
+
+```
+bash scripts/migrate-handoff-names.sh                  # dry-run
+bash scripts/migrate-handoff-names.sh --apply          # execute
+bash scripts/migrate-handoff-names.sh --apply <dir>    # override handoffs dir
+```
+
+### Rule application (first match wins)
+
+For each entry in `.startup/handoffs/`:
+
+1. **Skip canonical:** `INDEX.md` or `^[0-9]{3}-<canonical-direction>\.md$` — no action.
+
+2. **Move to `.startup/signoffs/`** — misplaced signoffs:
+   - filename matches `*roundtrip-signoff*.md`
+   - filename matches `*-signoff.md` (trailing)
+   - keeps the original filename intact in the destination (preserves NNN prefix when present)
+
+3. **Move to `.startup/reviews/`** — misplaced review artifacts:
+   - `*-qa-review.md`, `*-qa-pass.md`
+   - `*-business-review*.md`, `business-review-*.md`
+   - `*-business-qa*.md`, `business-qa-*.md`
+   - `*.lawyer.md` → rename to `lawyer-<basename-without-.lawyer.md>.md`
+   - `*.QA-PASS.md` → rename to `qa-pass-<basename-without-.QA-PASS.md>.md`
+   - `*-regression-tests-*.md`, `*-regression-results-*.md`
+   - `*ux-audit*.md`, `*ux-fixes*.md`
+   - `tribunal-*-to-tech*.md`, `*-tribunal-to-tech*.md`
+   - `*-tech-review-fixes*.md`, `*-tech-fixes*.md`
+   - `*-business-verification*.md`
+   - keeps the original filename intact in the destination (preserves NNN prefix when present)
+
+4. **Move to `.startup/attachments/`** — not a markdown handoff:
+   - any non-`.md` file (e.g., `.pdf`, `.png`, `.xbrl`)
+   - any directory
+   - creates `.startup/attachments/` if missing
+
+5. **Rename to canonical handoff** — infer direction, assign next-available NNN:
+   - First try: frontmatter `from:` / `to:` pair that maps to one of the 4 canonical directions
+   - Fallback: filename contains one of the 4 canonical-direction substrings (`business-to-tech`, `tech-to-business`, `business-to-growth`, `growth-to-business`)
+   - NNN assignment: `max_existing_NNN + 1`, incrementing; input sorted by mtime ascending (oldest first) so chronology is preserved
+
+6. **Manual review** — no rule matched:
+   - `investor-to-business*`, `investor-to-tech*` (human-origin; non-canonical role)
+   - `business-to-team*` (broadcast; no canonical equivalent)
+   - anything else unclassified
+   - left in place; listed in the dry-run output
+
+### NNN collision handling
+
+- Before renaming, compute `max_existing_NNN` from `ls .startup/handoffs/ | grep -oE '^[0-9]{3}'`.
+- Sort files-to-rename by mtime ascending.
+- Assign `max_existing_NNN + 1`, `max_existing_NNN + 2`, … sequentially.
+- This guarantees no collision with existing canonical files and no collision between renamed files.
+- Move operations (rules 2–4) do NOT draw from the NNN counter; they keep their original NNN prefix in the destination dir.
+
+### Destination collision handling (for moves)
+
+If a move would overwrite an existing file in the destination (rare — signoffs/ and reviews/ are sparsely populated):
+- Append `-dup<timestamp>` suffix to preserve both
+- Record in output
+
+### Dry-run output format
+
+```
+=== Handoff migration plan for /path/.startup/handoffs/ ===
+
+Skipping (already canonical): 451 files
+
+Move to .startup/signoffs/ (N files):
+  133-roundtrip-signoff.md → /path/.startup/signoffs/133-roundtrip-signoff.md
+  228-signoff.md → /path/.startup/signoffs/228-signoff.md
+  …
+
+Move to .startup/reviews/ (N files):
+  369-qa-review.md → /path/.startup/reviews/369-qa-review.md
+  business-to-tech-satisfaction-guarantee.lawyer.md
+    → /path/.startup/reviews/lawyer-business-to-tech-satisfaction-guarantee.md
+  …
+
+Move to .startup/attachments/ (N files):
+  arve_fixed_logo_preview.pdf → /path/.startup/attachments/arve_fixed_logo_preview.pdf
+  421-artifacts/ → /path/.startup/attachments/421-artifacts/
+  …
+
+Rename (N files, next NNN starts at XYZ):
+  2026-04-16T074318Z-business-to-tech-improve-189.md → XYZ-business-to-tech.md
+  business-to-tech-fix-invoice-logo-broken.md → XY(Z+1)-business-to-tech.md
+  …
+
+Manual review needed (N files, left in place):
+  205-investor-to-business.md    (reason: non-canonical role 'investor')
+  476-business-to-team.md        (reason: non-canonical recipient 'team')
+  …
+
+Summary: skip 451, move 70, rename 50, manual 15
+Dry-run — re-run with --apply to perform changes.
+```
+
+### --apply behavior
+
+- Performs all moves and renames using `mv`
+- Re-runs `backfill-handoff-index.sh` at the end to regenerate `INDEX.md` with new names
+- Prints the same section layout with `[DONE]` markers
+- Exits non-zero only on hard errors; manual-review entries are not errors
+
+## Component 3 — `hooks/hooks.json` wiring
+
+Add one new block at the end of the existing hook list:
+
+```json
+"PreToolUse": [
+  {
+    "matcher": "Write",
+    "hooks": [
+      {
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/scripts/enforce-handoff-naming.sh",
+        "description": "Block non-conforming handoff filenames (NNN-<direction>.md only)"
+      }
+    ]
+  }
+]
+```
+
+Placed alongside existing hook arrays at the top level of `hooks.hooks`.
+
+## Component 4 — `handoff-protocol.md` update
+
+Append a new "Enforcement" section after the existing "File Naming Convention" section:
+
+```markdown
+### Enforcement
+
+The canonical format is enforced by a PreToolUse hook (`enforce-handoff-naming.sh`).
+Writes to `.startup/handoffs/` that don't match `NNN-<direction>.md` (with one of the
+four canonical directions) are blocked with an error message that includes the next
+available NNN.
+
+Misrouted content:
+- Signoffs go in `.startup/signoffs/`
+- Review artifacts (QA, lawyer, UX audit, tribunal, regression) go in `.startup/reviews/`
+- Binaries and directories go in `.startup/attachments/`
+
+For legacy projects with pre-existing non-conforming files, run
+`bash $CLAUDE_PLUGIN_ROOT/scripts/migrate-handoff-names.sh` (dry-run) then
+`--apply` to clean up.
+```
+
+## Tests
+
+Add to `tests/run-tests.sh`:
+
+**Hook tests (`enforce-handoff-naming.sh`):**
+- Pass: canonical `NNN-business-to-tech.md` → exit 0
+- Pass: canonical `NNN-tech-to-business.md` → exit 0
+- Pass: `INDEX.md` → exit 0
+- Pass: path outside `.startup/handoffs/` → exit 0
+- Block: slug-only `business-to-tech-foo.md` → exit 2, message contains next NNN
+- Block: timestamp prefix → exit 2
+- Block: `.pdf` file → exit 2, message mentions `.startup/attachments/`
+- Block: non-canonical direction `NNN-business-to-team.md` → exit 2
+- Block: in empty dir → next NNN = `001`
+
+**Migration tests (`migrate-handoff-names.sh`):**
+- Fixture directory with one file from each category
+- Dry-run output contains each file in the expected section
+- `--apply` on the fixture moves/renames correctly
+- NNN assignment respects existing max and assigns sequentially
+- Destination collision in signoffs/ gets `-dup<ts>` suffix
+- Manual-review files are not touched
+
+Fixtures live under `tests/fixtures/migrate-handoff-names/`.
+
+## Aruannik validation plan
+
+1. Apply the version bump and code changes on a branch.
+2. Copy `scripts/migrate-handoff-names.sh` to aruannik temporarily or invoke via full path.
+3. Dry-run against `/mnt/data/ai/est-biz-aruannik/.startup/handoffs/`.
+4. Review the 6 sections — especially `manual review`.
+5. Run `--apply` once output is approved.
+6. Verify final state:
+   - `ls .startup/handoffs/ | grep -vE '^[0-9]{3}-(business-to-tech|tech-to-business|business-to-growth|growth-to-business)\.md$|^INDEX\.md$'` prints only the manual-review residue
+   - `INDEX.md` regenerated without `---` rows for moved/renamed files
+   - `.startup/signoffs/`, `.startup/reviews/`, `.startup/attachments/` populated as expected
+7. Touch-test the hook: attempt `Write .startup/handoffs/garbage.md` in a throwaway session; confirm the block message includes the correct next NNN.
+
+## Version bump
+
+- `plugins/saas-startup-team/.claude-plugin/plugin.json`: `0.32.0` → `0.33.0`
+- root `.claude-plugin/marketplace.json` entry for `saas-startup-team`: `0.32.0` → `0.33.0`
+
+Minor bump because this adds new functionality (hook + script) without breaking existing handoff consumers.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Migration renames break references in handoff contents that point to other handoffs by name | Low risk: canonical files are already canonically named; only slug→numbered transitions could break references, and no current agent workflow greps for slug filenames. Dry-run makes all renames visible before apply. |
+| Hook blocks legitimate writes where the agent made a typo | Error message includes next valid NNN + direction list. Agent re-Writes with corrected name on next turn. |
+| Downstream projects upgrade the plugin and get surprised by hook blocks on in-flight work | Hook matcher is `Write` only. Edits to existing files still pass. New writes get a clear actionable error, not a silent failure. |
+| Migration mis-routes a file (e.g., folds a legitimate "tech-fixes" handoff into reviews/) | Dry-run first; `--apply` is deliberate. User reviews each section before committing. |
+| Destination dir (`.startup/attachments/`) doesn't exist on target project | Migration creates it as needed. |
+| NNN collision with a handoff written concurrently during migration | Migration is a manual, one-shot operation run in a quiet session. Not a multi-writer scenario. |
+
+## Success criteria (from issue #21)
+
+- [x] New handoffs land in exactly one filename format (hook enforces, not just docs)
+- [x] Existing scripts handle every handoff without silent skips (after migration, everything is canonical)
+- [x] No binaries in `.startup/handoffs/` (moved to `.startup/attachments/`)

--- a/plugins/saas-startup-team/hooks/hooks.json
+++ b/plugins/saas-startup-team/hooks/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/enforce-handoff-naming.sh",
+            "description": "Block non-conforming handoff filenames (NNN-<direction>.md only)"
+          }
+        ]
+      }
+    ],
     "TeammateIdle": [
       {
         "hooks": [

--- a/plugins/saas-startup-team/scripts/enforce-handoff-naming.sh
+++ b/plugins/saas-startup-team/scripts/enforce-handoff-naming.sh
@@ -28,11 +28,15 @@ if [[ "$filename" =~ ^[0-9]{3}-(business-to-tech|tech-to-business|business-to-gr
   exit 0
 fi
 
-# Compute next available NNN for the error message
+# Compute next available NNN for the error message. Filter to canonical names
+# so pre-migration timestamp-prefixed files (e.g. 2026-04-16T...) don't poison
+# the max with their year prefix.
 handoff_dir=$(dirname "$file_path")
 next_nnn="001"
 if [ -d "$handoff_dir" ]; then
-  max=$(ls "$handoff_dir" 2>/dev/null | grep -oE '^[0-9]{3}' | sort -n | tail -1 || true)
+  max=$(ls "$handoff_dir" 2>/dev/null \
+    | grep -E '^[0-9]{3}-(business-to-tech|tech-to-business|business-to-growth|growth-to-business)\.md$' \
+    | grep -oE '^[0-9]{3}' | sort -n | tail -1 || true)
   if [ -n "$max" ]; then
     next_nnn=$(printf '%03d' $((10#$max + 1)))
   fi

--- a/plugins/saas-startup-team/scripts/enforce-handoff-naming.sh
+++ b/plugins/saas-startup-team/scripts/enforce-handoff-naming.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# enforce-handoff-naming.sh — PreToolUse hook for Write.
+# Blocks Writes under .startup/handoffs/ unless the filename is INDEX.md or
+# matches the canonical NNN-<direction>.md pattern. Exit 2 with systemMessage
+# on block; exit 0 otherwise (pass through).
+#
+# Input: JSON on stdin with tool_input.file_path
+# Exit 0: not a handoff path, or canonical name
+# Exit 2: blocked, systemMessage on stderr
+
+set -uo pipefail
+
+input=$(cat || true)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+[ -z "$file_path" ] && exit 0
+
+# Only act on writes under .startup/handoffs/
+case "$file_path" in
+  */.startup/handoffs/*) ;;
+  *) exit 0 ;;
+esac
+
+filename=$(basename "$file_path")
+[ "$filename" = "INDEX.md" ] && exit 0
+
+# Canonical format
+if [[ "$filename" =~ ^[0-9]{3}-(business-to-tech|tech-to-business|business-to-growth|growth-to-business)\.md$ ]]; then
+  exit 0
+fi
+
+# Compute next available NNN for the error message
+handoff_dir=$(dirname "$file_path")
+next_nnn="001"
+if [ -d "$handoff_dir" ]; then
+  max=$(ls "$handoff_dir" 2>/dev/null | grep -oE '^[0-9]{3}' | sort -n | tail -1 || true)
+  if [ -n "$max" ]; then
+    next_nnn=$(printf '%03d' $((10#$max + 1)))
+  fi
+fi
+
+msg="Handoff filename '${filename}' is not valid. Handoffs must be named NNN-<direction>.md where NNN is a zero-padded 3-digit number and <direction> is one of: business-to-tech, tech-to-business, business-to-growth, growth-to-business. Next available NNN: ${next_nnn}. Binaries (.pdf, .png) belong in .startup/attachments/; signoffs in .startup/signoffs/; reviews in .startup/reviews/."
+
+jq -n --arg msg "$msg" '{systemMessage: $msg}' >&2
+exit 2

--- a/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
+++ b/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# migrate-handoff-names.sh — one-time cleanup of .startup/handoffs/ to enforce
+# the canonical NNN-<direction>.md filename convention.
+#
+# Moves misplaced signoffs to .startup/signoffs/, reviews to .startup/reviews/,
+# binaries and directories to .startup/attachments/, and renames residual
+# topic-slug handoffs to NNN-<direction>.md with next-available numbers.
+#
+# Usage:
+#   bash migrate-handoff-names.sh                  # dry-run against git root
+#   bash migrate-handoff-names.sh --apply          # execute
+#   bash migrate-handoff-names.sh <handoff-dir>    # dry-run on explicit dir
+#   bash migrate-handoff-names.sh --apply <dir>    # execute on explicit dir
+
+set -uo pipefail
+
+APPLY=0
+HANDOFF_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) APPLY=1 ;;
+    -h|--help)
+      sed -n '2,13p' "$0"
+      exit 0 ;;
+    *) HANDOFF_DIR="$1" ;;
+  esac
+  shift
+done
+
+if [ -z "$HANDOFF_DIR" ]; then
+  GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Not in a git repo and no dir argument supplied." >&2
+    exit 1
+  }
+  HANDOFF_DIR="$GIT_ROOT/.startup/handoffs"
+fi
+
+if [ ! -d "$HANDOFF_DIR" ]; then
+  echo "Handoff dir not found: $HANDOFF_DIR" >&2
+  exit 1
+fi
+
+STARTUP_DIR=$(dirname "$HANDOFF_DIR")
+SIGNOFFS_DIR="$STARTUP_DIR/signoffs"
+REVIEWS_DIR="$STARTUP_DIR/reviews"
+ATTACH_DIR="$STARTUP_DIR/attachments"
+
+CANONICAL_RE='^[0-9]{3}-(business-to-tech|tech-to-business|business-to-growth|growth-to-business)\.md$'
+
+# Buckets: arrays of "<source>|<dest>" strings
+SKIP_COUNT=0
+MOVE_SIGNOFFS=()
+MOVE_REVIEWS=()
+MOVE_ATTACH=()
+RENAMES=()
+MANUAL=()
+
+# --- Scan pass ---
+shopt -s nullglob dotglob
+for entry in "$HANDOFF_DIR"/*; do
+  [ "$(basename "$entry")" = "INDEX.md" ] && { SKIP_COUNT=$((SKIP_COUNT + 1)); continue; }
+  filename=$(basename "$entry")
+
+  if [[ "$filename" =~ $CANONICAL_RE ]] && [ -f "$entry" ]; then
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+    continue
+  fi
+
+  # Rules 2-5 will be added in later tasks. For now, anything non-canonical
+  # goes to MANUAL so the skeleton produces correct counts on mixed dirs.
+  MANUAL+=("${entry}|(rules not yet implemented)")
+done
+shopt -u nullglob dotglob
+
+# --- Output ---
+echo "=== Handoff migration plan for ${HANDOFF_DIR} ==="
+echo ""
+echo "Skipping (already canonical): ${SKIP_COUNT}"
+echo ""
+
+if [ "${#MANUAL[@]}" -gt 0 ]; then
+  echo "Manual review needed (${#MANUAL[@]} files, left in place):"
+  for item in "${MANUAL[@]}"; do
+    src="${item%%|*}"
+    reason="${item##*|}"
+    echo "  $(basename "$src")    (reason: ${reason})"
+  done
+  echo ""
+fi
+
+echo "Summary: skip ${SKIP_COUNT}, move $((${#MOVE_SIGNOFFS[@]} + ${#MOVE_REVIEWS[@]} + ${#MOVE_ATTACH[@]})), rename ${#RENAMES[@]}, manual ${#MANUAL[@]}"
+
+if [ "$APPLY" -eq 0 ]; then
+  echo "Dry-run — re-run with --apply to perform changes."
+fi

--- a/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
+++ b/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
@@ -48,12 +48,52 @@ ATTACH_DIR="$STARTUP_DIR/attachments"
 
 CANONICAL_RE='^[0-9]{3}-(business-to-tech|tech-to-business|business-to-growth|growth-to-business)\.md$'
 
+# Map frontmatter from:/to: pair to canonical direction, or empty if no match.
+infer_from_frontmatter() {
+  local file="$1"
+  local from to
+  from=$(awk '/^from:/ {gsub(/"/,"",$0); sub(/^from:[[:space:]]*/,""); print; exit}' "$file" 2>/dev/null | tr -d '[:space:]')
+  to=$(awk '/^to:/ {gsub(/"/,"",$0); sub(/^to:[[:space:]]*/,""); print; exit}' "$file" 2>/dev/null | tr -d '[:space:]')
+  case "${from}→${to}" in
+    business-founder→tech-founder) echo "business-to-tech" ;;
+    tech-founder→business-founder) echo "tech-to-business" ;;
+    business-founder→growth-hacker) echo "business-to-growth" ;;
+    growth-hacker→business-founder) echo "growth-to-business" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Map filename substring to canonical direction, or empty if none found.
+# Longest match first so "business-to-growth" isn't shadowed by "business".
+infer_from_filename() {
+  local filename="$1"
+  for d in business-to-growth growth-to-business business-to-tech tech-to-business; do
+    case "$filename" in
+      *"$d"*) echo "$d"; return ;;
+    esac
+  done
+  echo ""
+}
+
+# Compute the maximum NNN prefix among canonical NNN-<direction>.md files
+# in the handoff dir (0 if none). Non-canonical 3-digit-prefix names (e.g.
+# timestamped files starting with 2026-...) are ignored on purpose.
+max_canonical_nnn() {
+  local dir="$1"
+  ls "$dir" 2>/dev/null \
+    | grep -E '^[0-9]{3}-(business-to-tech|tech-to-business|business-to-growth|growth-to-business)\.md$' \
+    | grep -oE '^[0-9]{3}' \
+    | sort -n \
+    | tail -1 || echo "0"
+}
+
 # Buckets: arrays of "<source>|<dest>" strings
 SKIP_COUNT=0
 MOVE_SIGNOFFS=()
 MOVE_REVIEWS=()
 MOVE_ATTACH=()
 RENAMES=()
+RENAME_CANDIDATES=()
 MANUAL=()
 
 # --- Scan pass ---
@@ -115,10 +155,38 @@ for entry in "$HANDOFF_DIR"/*; do
       continue ;;
   esac
 
-  # Fallthrough — leave unresolved for now; rules 5–6 added in later task
-  MANUAL+=("${entry}|(rules 5-6 not yet implemented)")
+  # Rule 5: infer canonical direction
+  direction=$(infer_from_frontmatter "$entry")
+  if [ -z "$direction" ]; then
+    direction=$(infer_from_filename "$filename")
+  fi
+  if [ -n "$direction" ]; then
+    # Defer NNN assignment — collect into a rename candidate list with mtime
+    mtime=$(stat -c '%Y' "$entry" 2>/dev/null || stat -f '%m' "$entry" 2>/dev/null || echo 0)
+    RENAME_CANDIDATES+=("${mtime}|${entry}|${direction}")
+    continue
+  fi
+
+  # Rule 6: manual review
+  MANUAL+=("${entry}|no canonical direction in filename or frontmatter")
 done
 shopt -u nullglob dotglob
+
+# Assign NNNs to rename candidates in mtime order, starting at max+1.
+max_nnn=$(max_canonical_nnn "$HANDOFF_DIR")
+max_nnn=$((10#${max_nnn:-0}))
+if [ "${#RENAME_CANDIDATES[@]}" -gt 0 ]; then
+  # Sort by mtime (ascending)
+  IFS=$'\n' sorted=($(printf '%s\n' "${RENAME_CANDIDATES[@]}" | sort -t'|' -k1,1n))
+  unset IFS
+  for item in "${sorted[@]}"; do
+    src="${item#*|}"; src="${src%%|*}"          # middle field
+    direction="${item##*|}"
+    max_nnn=$((max_nnn + 1))
+    nnn=$(printf '%03d' "$max_nnn")
+    RENAMES+=("${src}|${HANDOFF_DIR}/${nnn}-${direction}.md")
+  done
+fi
 
 # --- Output ---
 echo "=== Handoff migration plan for ${HANDOFF_DIR} ==="

--- a/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
+++ b/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
@@ -59,17 +59,64 @@ MANUAL=()
 # --- Scan pass ---
 shopt -s nullglob dotglob
 for entry in "$HANDOFF_DIR"/*; do
-  [ "$(basename "$entry")" = "INDEX.md" ] && { SKIP_COUNT=$((SKIP_COUNT + 1)); continue; }
   filename=$(basename "$entry")
+  [ "$filename" = "INDEX.md" ] && { SKIP_COUNT=$((SKIP_COUNT + 1)); continue; }
 
-  if [[ "$filename" =~ $CANONICAL_RE ]] && [ -f "$entry" ]; then
+  # Canonical file — skip
+  if [ -f "$entry" ] && [[ "$filename" =~ $CANONICAL_RE ]]; then
     SKIP_COUNT=$((SKIP_COUNT + 1))
     continue
   fi
 
-  # Rules 2-5 will be added in later tasks. For now, anything non-canonical
-  # goes to MANUAL so the skeleton produces correct counts on mixed dirs.
-  MANUAL+=("${entry}|(rules not yet implemented)")
+  # Rule 2: signoffs → .startup/signoffs/
+  case "$filename" in
+    *roundtrip-signoff*.md|*-signoff.md|signoff-*.md)
+      MOVE_SIGNOFFS+=("${entry}|${SIGNOFFS_DIR}/${filename}")
+      continue ;;
+  esac
+
+  # Rule 3: review artifacts → .startup/reviews/
+  # Match a range of review-like patterns. Rename .lawyer.md / .QA-PASS.md
+  # variants into cleaner names on the way out.
+  dest_name="$filename"
+  matched_review=0
+  case "$filename" in
+    *.lawyer.md)
+      base="${filename%.lawyer.md}"
+      dest_name="lawyer-${base}.md"
+      matched_review=1 ;;
+    *.QA-PASS.md)
+      base="${filename%.QA-PASS.md}"
+      dest_name="qa-pass-${base}.md"
+      matched_review=1 ;;
+    *-qa-review.md|*-qa-pass.md) matched_review=1 ;;
+    *-business-review*.md|business-review-*.md) matched_review=1 ;;
+    *-business-qa*.md|business-qa-*.md) matched_review=1 ;;
+    *-regression-tests-*.md|*-regression-results-*.md) matched_review=1 ;;
+    *ux-audit*.md|*ux-fixes*.md) matched_review=1 ;;
+    tribunal-*-to-tech*.md|*-tribunal-to-tech*.md|*-tribunal-review-to-tech*.md) matched_review=1 ;;
+    *-tech-review-fixes*.md|*-tech-fixes*.md) matched_review=1 ;;
+    *-business-verification*.md) matched_review=1 ;;
+  esac
+  if [ "$matched_review" = "1" ]; then
+    MOVE_REVIEWS+=("${entry}|${REVIEWS_DIR}/${dest_name}")
+    continue
+  fi
+
+  # Rule 4: non-.md or directory → .startup/attachments/
+  if [ -d "$entry" ]; then
+    MOVE_ATTACH+=("${entry}|${ATTACH_DIR}/${filename}")
+    continue
+  fi
+  case "$filename" in
+    *.md) ;;
+    *)
+      MOVE_ATTACH+=("${entry}|${ATTACH_DIR}/${filename}")
+      continue ;;
+  esac
+
+  # Fallthrough — leave unresolved for now; rules 5–6 added in later task
+  MANUAL+=("${entry}|(rules 5-6 not yet implemented)")
 done
 shopt -u nullglob dotglob
 
@@ -78,6 +125,34 @@ echo "=== Handoff migration plan for ${HANDOFF_DIR} ==="
 echo ""
 echo "Skipping (already canonical): ${SKIP_COUNT}"
 echo ""
+
+print_move_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+  [ "${#items[@]}" -eq 0 ] && return
+  echo "${title} (${#items[@]} files):"
+  for item in "${items[@]}"; do
+    src="${item%%|*}"
+    dest="${item##*|}"
+    echo "  $(basename "$src") → ${dest}"
+  done
+  echo ""
+}
+
+print_move_section "Move to .startup/signoffs/" "${MOVE_SIGNOFFS[@]}"
+print_move_section "Move to .startup/reviews/" "${MOVE_REVIEWS[@]}"
+print_move_section "Move to .startup/attachments/" "${MOVE_ATTACH[@]}"
+
+if [ "${#RENAMES[@]}" -gt 0 ]; then
+  echo "Rename (${#RENAMES[@]} files):"
+  for item in "${RENAMES[@]}"; do
+    src="${item%%|*}"
+    dest="${item##*|}"
+    echo "  $(basename "$src") → $(basename "$dest")"
+  done
+  echo ""
+fi
 
 if [ "${#MANUAL[@]}" -gt 0 ]; then
   echo "Manual review needed (${#MANUAL[@]} files, left in place):"

--- a/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
+++ b/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
@@ -237,3 +237,41 @@ echo "Summary: skip ${SKIP_COUNT}, move $((${#MOVE_SIGNOFFS[@]} + ${#MOVE_REVIEW
 if [ "$APPLY" -eq 0 ]; then
   echo "Dry-run — re-run with --apply to perform changes."
 fi
+
+# --- Apply pass ---
+if [ "$APPLY" -ne 1 ]; then
+  exit 0
+fi
+
+mkdir -p "$SIGNOFFS_DIR" "$REVIEWS_DIR" "$ATTACH_DIR"
+
+apply_move() {
+  local src="$1" dest="$2"
+  if [ -e "$dest" ]; then
+    local ts
+    ts=$(date +%Y%m%d%H%M%S)
+    local base="${dest%.*}"
+    local ext="${dest##*.}"
+    if [ "$base" = "$dest" ]; then
+      dest="${dest}-dup${ts}"
+    else
+      dest="${base}-dup${ts}.${ext}"
+    fi
+  fi
+  mv "$src" "$dest"
+}
+
+for item in "${MOVE_SIGNOFFS[@]}"; do apply_move "${item%%|*}" "${item##*|}"; done
+for item in "${MOVE_REVIEWS[@]}"; do apply_move "${item%%|*}" "${item##*|}"; done
+for item in "${MOVE_ATTACH[@]}"; do apply_move "${item%%|*}" "${item##*|}"; done
+for item in "${RENAMES[@]}"; do apply_move "${item%%|*}" "${item##*|}"; done
+
+echo ""
+echo "[DONE] Applied: ${#MOVE_SIGNOFFS[@]} signoffs, ${#MOVE_REVIEWS[@]} reviews, ${#MOVE_ATTACH[@]} attachments, ${#RENAMES[@]} renames."
+
+# Regenerate INDEX.md to reflect the new state
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -x "$SCRIPT_DIR/backfill-handoff-index.sh" ]; then
+  echo "Regenerating $HANDOFF_DIR/INDEX.md..."
+  bash "$SCRIPT_DIR/backfill-handoff-index.sh" "$HANDOFF_DIR"
+fi

--- a/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
+++ b/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
@@ -245,20 +245,25 @@ fi
 
 mkdir -p "$SIGNOFFS_DIR" "$REVIEWS_DIR" "$ATTACH_DIR"
 
+APPLY_FAIL_COUNT=0
+
 apply_move() {
   local src="$1" dest="$2"
   if [ -e "$dest" ]; then
-    local ts
+    local ts dir name base ext
     ts=$(date +%Y%m%d%H%M%S)
-    local base="${dest%.*}"
-    local ext="${dest##*.}"
-    if [ "$base" = "$dest" ]; then
-      dest="${dest}-dup${ts}"
-    else
-      dest="${base}-dup${ts}.${ext}"
-    fi
+    dir=$(dirname "$dest")
+    name=$(basename "$dest")
+    case "$name" in
+      *.*) base="${name%.*}"; ext="${name##*.}"; dest="${dir}/${base}-dup${ts}.${ext}" ;;
+      *)   dest="${dir}/${name}-dup${ts}" ;;
+    esac
   fi
-  mv "$src" "$dest"
+  if ! mv "$src" "$dest"; then
+    echo "[WARN] mv failed: $src → $dest" >&2
+    APPLY_FAIL_COUNT=$((APPLY_FAIL_COUNT + 1))
+    return 1
+  fi
 }
 
 for item in "${MOVE_SIGNOFFS[@]}"; do apply_move "${item%%|*}" "${item##*|}"; done
@@ -268,6 +273,9 @@ for item in "${RENAMES[@]}"; do apply_move "${item%%|*}" "${item##*|}"; done
 
 echo ""
 echo "[DONE] Applied: ${#MOVE_SIGNOFFS[@]} signoffs, ${#MOVE_REVIEWS[@]} reviews, ${#MOVE_ATTACH[@]} attachments, ${#RENAMES[@]} renames."
+if [ "$APPLY_FAIL_COUNT" -gt 0 ]; then
+  echo "[WARN] ${APPLY_FAIL_COUNT} mv operation(s) failed — review output above."
+fi
 
 # Regenerate INDEX.md to reflect the new state
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
+++ b/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
@@ -65,6 +65,8 @@ infer_from_frontmatter() {
 
 # Map filename substring to canonical direction, or empty if none found.
 # Longest match first so "business-to-growth" isn't shadowed by "business".
+# Orphan roles (investor, team, team-lead) fold into the closest canonical
+# direction — lossy but keeps the handoffs dir clean.
 infer_from_filename() {
   local filename="$1"
   for d in business-to-growth growth-to-business business-to-tech tech-to-business; do
@@ -72,6 +74,12 @@ infer_from_filename() {
       *"$d"*) echo "$d"; return ;;
     esac
   done
+  case "$filename" in
+    *investor-to-tech*|*investor-to-business*|*business-to-team*)
+      echo "business-to-tech"; return ;;
+    *tech-to-team-lead*|*tech-to-team*)
+      echo "tech-to-business"; return ;;
+  esac
   echo ""
 }
 
@@ -132,7 +140,7 @@ for entry in "$HANDOFF_DIR"/*; do
     *-qa-review.md|*-qa-pass.md) matched_review=1 ;;
     *-business-review*.md|business-review-*.md) matched_review=1 ;;
     *-business-qa*.md|business-qa-*.md) matched_review=1 ;;
-    *-regression-tests-*.md|*-regression-results-*.md) matched_review=1 ;;
+    *regression-tests*.md|*regression-results*.md|*sequencing-plan*.md) matched_review=1 ;;
     *ux-audit*.md|*ux-fixes*.md) matched_review=1 ;;
     tribunal-*-to-tech*.md|*-tribunal-to-tech*.md|*-tribunal-review-to-tech*.md) matched_review=1 ;;
     *-tech-review-fixes*.md|*-tech-fixes*.md) matched_review=1 ;;

--- a/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
+++ b/plugins/saas-startup-team/scripts/migrate-handoff-names.sh
@@ -291,3 +291,8 @@ if [ -x "$SCRIPT_DIR/backfill-handoff-index.sh" ]; then
   echo "Regenerating $HANDOFF_DIR/INDEX.md..."
   bash "$SCRIPT_DIR/backfill-handoff-index.sh" "$HANDOFF_DIR"
 fi
+
+# Signal partial failure to automation via non-zero exit.
+if [ "$APPLY_FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi

--- a/plugins/saas-startup-team/skills/startup-orchestration/references/handoff-protocol.md
+++ b/plugins/saas-startup-team/skills/startup-orchestration/references/handoff-protocol.md
@@ -84,6 +84,24 @@ Example lookups:
 
 For legacy projects that predate the hook, rebuild the index once with `bash $CLAUDE_PLUGIN_ROOT/scripts/backfill-handoff-index.sh`.
 
+### Enforcement
+
+The canonical format is enforced by a PreToolUse hook (`enforce-handoff-naming.sh`). Writes to `.startup/handoffs/` that don't match `NNN-<direction>.md` with one of the four canonical directions are blocked with an error message that names the next available NNN.
+
+Misrouted content has dedicated homes:
+- Signoffs → `.startup/signoffs/`
+- Review artifacts (QA, lawyer, UX audit, tribunal, regression) → `.startup/reviews/`
+- Binaries and directories → `.startup/attachments/`
+
+For legacy projects with pre-existing non-conforming files, run the one-time migration script:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/migrate-handoff-names.sh          # dry-run, review the plan
+bash $CLAUDE_PLUGIN_ROOT/scripts/migrate-handoff-names.sh --apply  # execute
+```
+
+The migration moves misrouted content to the right subdirectory and renames residual topic-slug handoffs to `NNN-<direction>.md` with next-available numbers. Sort is by mtime so chronology is preserved.
+
 ## Handoff Validation Checklist
 
 ### For Business-to-Tech:

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -2025,6 +2025,43 @@ test_migrate_handoff_names() {
   assert_exit_code "S3: canonical-only exits 0" "$ec" 0
   assert_output_contains "S3b: skip count is 2" "$output" "Skipping (already canonical): 2"
   rm -rf "$workdir"
+
+  # S4: roundtrip-signoff moves to signoffs/
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/133-roundtrip-signoff.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S4: dry-run with signoff exits 0" "$ec" 0
+  assert_output_contains "S4b: plan moves to signoffs/" "$output" "Move to .startup/signoffs/"
+  assert_output_contains "S4c: plan lists 133-roundtrip-signoff" "$output" "133-roundtrip-signoff.md"
+  rm -rf "$workdir"
+
+  # S5: qa-review moves to reviews/
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/369-qa-review.md"
+  touch "$workdir/.startup/handoffs/business-to-tech-satisfaction-guarantee.lawyer.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S5: plan moves to reviews/" "$output" "Move to .startup/reviews/"
+  assert_output_contains "S5b: plan lists qa-review file" "$output" "369-qa-review.md"
+  assert_output_contains "S5c: .lawyer.md renamed to lawyer-*" "$output" "lawyer-business-to-tech-satisfaction-guarantee.md"
+  rm -rf "$workdir"
+
+  # S6: binary moves to attachments/
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/arve_fixed_logo_preview.pdf"
+  touch "$workdir/.startup/handoffs/arve_fixed_logo_preview.png"
+  mkdir -p "$workdir/.startup/handoffs/421-artifacts"
+  touch "$workdir/.startup/handoffs/421-artifacts/sample.pdf"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S6: plan moves to attachments/" "$output" "Move to .startup/attachments/"
+  assert_output_contains "S6b: plan lists pdf" "$output" "arve_fixed_logo_preview.pdf"
+  assert_output_contains "S6c: plan lists directory" "$output" "421-artifacts"
+  rm -rf "$workdir"
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -2117,6 +2117,54 @@ EOF
   output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
   assert_output_contains "S9: frontmatter-derived direction wins" "$output" "business-to-tech-misnamed.md → 001-tech-to-business.md"
   rm -rf "$workdir"
+
+  # S10: --apply performs moves and renames
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/001-business-to-tech.md"
+  touch "$workdir/.startup/handoffs/133-roundtrip-signoff.md"
+  touch "$workdir/.startup/handoffs/369-qa-review.md"
+  touch "$workdir/.startup/handoffs/arve.pdf"
+  touch "$workdir/.startup/handoffs/business-to-tech-foo.md"
+  ec=0
+  output=$(bash "$script" --apply "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S10: --apply exits 0" "$ec" 0
+  assert_file_exists "S10b: canonical preserved" "$workdir/.startup/handoffs/001-business-to-tech.md"
+  assert_file_exists "S10c: signoff moved" "$workdir/.startup/signoffs/133-roundtrip-signoff.md"
+  assert_file_exists "S10d: review moved" "$workdir/.startup/reviews/369-qa-review.md"
+  assert_file_exists "S10e: binary moved" "$workdir/.startup/attachments/arve.pdf"
+  assert_file_exists "S10f: slug renamed to 002-business-to-tech.md" "$workdir/.startup/handoffs/002-business-to-tech.md"
+  # Source filenames must no longer exist in handoffs/
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if [ ! -e "$workdir/.startup/handoffs/business-to-tech-foo.md" ]; then
+    echo -e "  ${GREEN}PASS${NC} S10g: source slug removed from handoffs/"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} S10g: source slug still in handoffs/"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("S10g: source slug not removed")
+  fi
+  assert_file_exists "S10h: INDEX.md regenerated" "$workdir/.startup/handoffs/INDEX.md"
+  rm -rf "$workdir"
+
+  # S11: --apply collision appends -dup suffix
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs" "$workdir/.startup/signoffs"
+  touch "$workdir/.startup/handoffs/133-roundtrip-signoff.md"
+  touch "$workdir/.startup/signoffs/133-roundtrip-signoff.md"  # pre-existing
+  ec=0
+  output=$(bash "$script" --apply "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S11: collision exits 0" "$ec" 0
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if ls "$workdir/.startup/signoffs/"*-dup* >/dev/null 2>&1; then
+    echo -e "  ${GREEN}PASS${NC} S11b: collision produces -dup file"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} S11b: no -dup file in signoffs/"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("S11b: no -dup file")
+  fi
+  rm -rf "$workdir"
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -470,6 +470,24 @@ test_plugin_config() {
   assert_output_contains "E8: hooks.json has TeammateIdle" "$hooks_keys" "TeammateIdle"
   assert_output_contains "E9: hooks.json has TaskCompleted" "$hooks_keys" "TaskCompleted"
   assert_output_contains "E10: hooks.json has Stop" "$hooks_keys" "Stop"
+
+  # C-enforce: PreToolUse enforce-handoff-naming.sh is registered
+  local enforce_cmd
+  enforce_cmd=$(jq -r '.hooks.PreToolUse[]?.hooks[]?.command // empty' "$PLUGIN_ROOT/hooks/hooks.json" | grep -F "enforce-handoff-naming.sh" || true)
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if [ -n "$enforce_cmd" ]; then
+    echo -e "  ${GREEN}PASS${NC} C-enforce: PreToolUse hook registers enforce-handoff-naming.sh"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} C-enforce: PreToolUse hook does not register enforce-handoff-naming.sh"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("C-enforce: missing enforce-handoff-naming.sh in PreToolUse")
+  fi
+
+  # C-enforce-matcher: the entry uses matcher "Write"
+  local enforce_matcher
+  enforce_matcher=$(jq -r '.hooks.PreToolUse[]? | select(.hooks[]?.command | test("enforce-handoff-naming.sh")) | .matcher // empty' "$PLUGIN_ROOT/hooks/hooks.json")
+  assert_equals "C-enforce-matcher: matcher is Write" "$enforce_matcher" "Write"
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -2205,6 +2205,28 @@ EOF
   assert_output_not_contains "S13e: no manual review" "$output" "Manual review needed"
   rm -rf "$workdir"
 
+  # S13e: --apply exits non-zero when a mv operation fails
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  # Pre-create a read-only destination dir so mv into it will fail
+  mkdir -p "$workdir/.startup/attachments"
+  touch "$workdir/.startup/handoffs/broken.pdf"
+  chmod -w "$workdir/.startup/attachments"
+  ec=0
+  output=$(bash "$script" --apply "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  chmod +w "$workdir/.startup/attachments"
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if [ "$ec" -ne 0 ]; then
+    echo -e "  ${GREEN}PASS${NC} S13f: --apply exits non-zero on mv failure (got $ec)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} S13f: --apply exited 0 despite mv failure"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("S13f: --apply should exit non-zero on mv failure")
+  fi
+  assert_output_contains "S13g: warning line present" "$output" "[WARN]"
+  rm -rf "$workdir"
+
   # S14: widened review rule catches regression-results without trailing hyphen + sequencing-plan
   workdir=$(mktemp -d)
   mkdir -p "$workdir/.startup/handoffs"

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -2165,6 +2165,29 @@ EOF
     FAILURES+=("S11b: no -dup file")
   fi
   rm -rf "$workdir"
+
+  # S12: directory collision in attachments/ — extensionless dest doesn't corrupt path
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs/421-artifacts"
+  mkdir -p "$workdir/.startup/attachments/421-artifacts"  # pre-existing dir
+  touch "$workdir/.startup/handoffs/421-artifacts/x.txt"
+  touch "$workdir/.startup/attachments/421-artifacts/y.txt"
+  ec=0
+  output=$(bash "$script" --apply "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S12: dir collision exits 0" "$ec" 0
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if ls -d "$workdir/.startup/attachments/421-artifacts-dup"*/ >/dev/null 2>&1; then
+    echo -e "  ${GREEN}PASS${NC} S12b: extensionless dir collision produces -dup suffix"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} S12b: no -dup dir in attachments/"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("S12b: no -dup dir")
+  fi
+  # The original pre-existing dir must still exist (only the new one got renamed)
+  assert_file_exists "S12c: pre-existing attachments/421-artifacts preserved" "$workdir/.startup/attachments/421-artifacts/y.txt"
+  assert_output_not_contains "S12d: no WARN lines" "$output" "[WARN]"
+  rm -rf "$workdir"
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -2188,6 +2188,35 @@ EOF
   assert_file_exists "S12c: pre-existing attachments/421-artifacts preserved" "$workdir/.startup/attachments/421-artifacts/y.txt"
   assert_output_not_contains "S12d: no WARN lines" "$output" "[WARN]"
   rm -rf "$workdir"
+
+  # S13: orphan roles fold to canonical directions (investor, team, team-lead)
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/205-investor-to-business.md"
+  touch "$workdir/.startup/handoffs/225-investor-to-tech.md"
+  touch "$workdir/.startup/handoffs/476-business-to-team.md"
+  touch "$workdir/.startup/handoffs/tech-to-team-lead-fixes.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S13: investor-to-business folds to business-to-tech" "$output" "205-investor-to-business.md → 001-business-to-tech.md"
+  assert_output_contains "S13b: investor-to-tech folds to business-to-tech" "$output" "225-investor-to-tech.md → 002-business-to-tech.md"
+  assert_output_contains "S13c: business-to-team folds to business-to-tech" "$output" "476-business-to-team.md → 003-business-to-tech.md"
+  assert_output_contains "S13d: tech-to-team-lead folds to tech-to-business" "$output" "tech-to-team-lead-fixes.md → 004-tech-to-business.md"
+  assert_output_not_contains "S13e: no manual review" "$output" "Manual review needed"
+  rm -rf "$workdir"
+
+  # S14: widened review rule catches regression-results without trailing hyphen + sequencing-plan
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/317-regression-results.md"
+  touch "$workdir/.startup/handoffs/311-sequencing-plan.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S14: regression-results routed to reviews/" "$output" "317-regression-results.md"
+  assert_output_contains "S14b: sequencing-plan routed to reviews/" "$output" "311-sequencing-plan.md"
+  assert_output_contains "S14c: both in reviews section" "$output" "Move to .startup/reviews/ (2 files)"
+  assert_output_not_contains "S14d: no manual review" "$output" "Manual review needed"
+  rm -rf "$workdir"
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -2062,6 +2062,50 @@ test_migrate_handoff_names() {
   assert_output_contains "S6b: plan lists pdf" "$output" "arve_fixed_logo_preview.pdf"
   assert_output_contains "S6c: plan lists directory" "$output" "421-artifacts"
   rm -rf "$workdir"
+
+  # S7: topic-slug renames to next-available NNN
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/012-business-to-tech.md"
+  # older slug file — should get NNN 013
+  touch -t 202603010000 "$workdir/.startup/handoffs/business-to-tech-foo.md"
+  # newer slug file — should get NNN 014
+  touch -t 202603020000 "$workdir/.startup/handoffs/tech-to-business-bar.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S7: rename section present" "$output" "Rename"
+  assert_output_contains "S7b: foo → 013-business-to-tech" "$output" "business-to-tech-foo.md → 013-business-to-tech.md"
+  assert_output_contains "S7c: bar → 014-tech-to-business" "$output" "tech-to-business-bar.md → 014-tech-to-business.md"
+  rm -rf "$workdir"
+
+  # S8: timestamp-prefix renames with canonical direction extracted
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/2026-04-16T074318Z-business-to-tech-improve-189.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S8: timestamp file renamed to business-to-tech" "$output" "2026-04-16T074318Z-business-to-tech-improve-189.md → 001-business-to-tech.md"
+  rm -rf "$workdir"
+
+  # S9: frontmatter wins over filename
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  cat > "$workdir/.startup/handoffs/business-to-tech-misnamed.md" <<'EOF'
+---
+from: tech-founder
+to: business-founder
+iteration: 3
+date: 2026-04-10
+type: implementation
+---
+
+## Summary
+Actually a tech-to-business handoff misnamed.
+EOF
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_output_contains "S9: frontmatter-derived direction wins" "$output" "business-to-tech-misnamed.md → 001-tech-to-business.md"
+  rm -rf "$workdir"
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -1973,6 +1973,17 @@ test_enforce_handoff_naming_hook() {
   assert_output_contains "R11b: next NNN is 013" "$output" "013"
   rm -rf "$workdir"
 
+  # R11c: pre-migration timestamp-prefixed files don't poison max NNN
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/005-business-to-tech.md"
+  touch "$workdir/.startup/handoffs/2026-04-16T074318Z-business-to-tech-improve-189.md"
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"'"$workdir"'/.startup/handoffs/bogus.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R11c: exits 2" "$ec" 2
+  assert_output_contains "R11d: next NNN ignores timestamp prefix, is 006" "$output" "006"
+  rm -rf "$workdir"
+
   # R12: empty file_path in stdin passes (defensive)
   ec=0
   output=$(echo '{}' | bash "$script" 2>&1) || ec=$?

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -1985,6 +1985,49 @@ test_enforce_handoff_naming_hook() {
 }
 
 # ---------------------------------------------------------------------------
+# Suite S: Migrate Handoff Names (migrate-handoff-names.sh)
+# ---------------------------------------------------------------------------
+
+test_migrate_handoff_names() {
+  echo -e "\n${CYAN}Suite S: migrate-handoff-names.sh${NC}"
+  local script="$PLUGIN_ROOT/scripts/migrate-handoff-names.sh"
+  local workdir ec output
+
+  # S1: script exists and is executable
+  assert_file_exists "S1: migrate-handoff-names.sh exists" "$script"
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if [ -x "$script" ]; then
+    echo -e "  ${GREEN}PASS${NC} S1b: script is executable"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} S1b: script is not executable"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("S1b: script is not executable")
+  fi
+
+  # S2: dry-run on empty dir returns 0 with summary
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S2: empty dir dry-run exits 0" "$ec" 0
+  assert_output_contains "S2b: output says dry-run" "$output" "Dry-run"
+  assert_output_contains "S2c: summary line present" "$output" "Summary:"
+  rm -rf "$workdir"
+
+  # S3: canonical-only dir — nothing to change
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/001-business-to-tech.md"
+  touch "$workdir/.startup/handoffs/002-tech-to-business.md"
+  ec=0
+  output=$(bash "$script" "$workdir/.startup/handoffs" 2>&1) || ec=$?
+  assert_exit_code "S3: canonical-only exits 0" "$ec" 0
+  assert_output_contains "S3b: skip count is 2" "$output" "Skipping (already canonical): 2"
+  rm -rf "$workdir"
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -2018,6 +2061,7 @@ main() {
   test_migrate_state
   test_index_handoff_hook
   test_enforce_handoff_naming_hook
+  test_migrate_handoff_names
 
   # Summary
   echo ""

--- a/plugins/saas-startup-team/tests/run-tests.sh
+++ b/plugins/saas-startup-team/tests/run-tests.sh
@@ -1873,6 +1873,100 @@ test_migrate_state() {
 }
 
 # ---------------------------------------------------------------------------
+# Suite R: Enforce Handoff Naming Hook (enforce-handoff-naming.sh)
+# ---------------------------------------------------------------------------
+
+test_enforce_handoff_naming_hook() {
+  echo -e "\n${CYAN}Suite R: enforce-handoff-naming.sh${NC}"
+  local script="$PLUGIN_ROOT/scripts/enforce-handoff-naming.sh"
+  local workdir ec output
+
+  # R1: script exists and is executable
+  assert_file_exists "R1: enforce-handoff-naming.sh exists" "$script"
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+  if [ -x "$script" ]; then
+    echo -e "  ${GREEN}PASS${NC} R1b: script is executable"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} R1b: script is not executable"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("R1b: script is not executable")
+  fi
+
+  # R2: path outside .startup/handoffs/ passes
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/src/main.py"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R2: outside handoffs exits 0" "$ec" 0
+
+  # R3: INDEX.md passes
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/INDEX.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R3: INDEX.md exits 0" "$ec" 0
+
+  # R4: canonical business-to-tech passes
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/001-business-to-tech.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R4: canonical business-to-tech exits 0" "$ec" 0
+
+  # R5: canonical tech-to-business passes
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/042-tech-to-business.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R5: canonical tech-to-business exits 0" "$ec" 0
+
+  # R6: canonical business-to-growth passes
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/007-business-to-growth.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R6: canonical business-to-growth exits 0" "$ec" 0
+
+  # R7: slug-only filename is blocked
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"'"$workdir"'/.startup/handoffs/business-to-tech-foo.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R7: slug-only filename exits 2" "$ec" 2
+  assert_output_contains "R7b: block message mentions NNN" "$output" "NNN"
+  assert_output_contains "R7c: block message mentions next NNN 001" "$output" "001"
+  rm -rf "$workdir"
+
+  # R8: timestamp-prefixed filename is blocked
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/2026-04-16T074318Z-business-to-tech-improve-189.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R8: timestamp-prefix exits 2" "$ec" 2
+
+  # R9: non-.md (binary) is blocked
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/sample.pdf"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R9: .pdf exits 2" "$ec" 2
+  assert_output_contains "R9b: block message mentions attachments/" "$output" "attachments"
+
+  # R10: non-canonical direction NNN-business-to-team is blocked
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/handoffs/476-business-to-team.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R10: non-canonical direction exits 2" "$ec" 2
+
+  # R11: next-NNN computation reflects actual max
+  workdir=$(mktemp -d)
+  mkdir -p "$workdir/.startup/handoffs"
+  touch "$workdir/.startup/handoffs/012-business-to-tech.md"
+  touch "$workdir/.startup/handoffs/007-tech-to-business.md"
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"'"$workdir"'/.startup/handoffs/bogus.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R11: block with existing files exits 2" "$ec" 2
+  assert_output_contains "R11b: next NNN is 013" "$output" "013"
+  rm -rf "$workdir"
+
+  # R12: empty file_path in stdin passes (defensive)
+  ec=0
+  output=$(echo '{}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R12: empty input exits 0" "$ec" 0
+
+  # R13: signoffs/ path is not blocked (not a handoff path)
+  ec=0
+  output=$(echo '{"tool_input":{"file_path":"/workspace/.startup/signoffs/roundtrip-001.md"}}' | bash "$script" 2>&1) || ec=$?
+  assert_exit_code "R13: signoffs/ path exits 0" "$ec" 0
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -1905,6 +1999,7 @@ main() {
   test_compact_state
   test_migrate_state
   test_index_handoff_hook
+  test_enforce_handoff_naming_hook
 
   # Summary
   echo ""


### PR DESCRIPTION
Closes #21.

## Summary
- New PreToolUse hook `enforce-handoff-naming.sh` blocks Writes under `.startup/handoffs/` that don't match canonical `NNN-<direction>.md` (four canonical directions). Error message names the next available NNN and points misrouted content to `signoffs/`, `reviews/`, or `attachments/`.
- New one-shot migration script `migrate-handoff-names.sh` (dry-run by default; `--apply` to execute). Moves misrouted signoffs/reviews/binaries to their proper `.startup/` subdirs, renames topic-slug and timestamp-prefix handoffs to canonical `NNN-<direction>.md` with sequential mtime-sorted numbers, folds orphan roles (`investor-to-*`, `business-to-team`, `tech-to-team-lead`) into the closest canonical direction, and regenerates `INDEX.md` via `backfill-handoff-index.sh`.
- Plugin bumped 0.32.0 → 0.33.0.

## Validation against aruannik (586-file reference project)
- 38 signoffs → `signoffs/`, 39 reviews → `reviews/`, 3 attachments (incl. `421-artifacts/` directory + PDFs) → `attachments/`, 61 renamed to canonical
- Zero non-canonical residue in `handoffs/` after `--apply`
- Hook touch-test: blocks `garbage-name.md` with correct computed `next_nnn: 588`

## Reviewer-caught issues fixed during implementation
- `max_canonical_nnn` tightened to filter by canonical regex (would otherwise pick `202` from timestamp-prefixed filenames)
- `enforce-handoff-naming.sh` aligned with the same filter
- `apply_move` collision handling switched to basename split (was corrupting extensionless destinations like `.startup/attachments/421-artifacts`)
- `mv` failures surface via `APPLY_FAIL_COUNT` instead of silently masking a botched migration

## Tests
- Suite R (13 groups / 19 assertions) — PreToolUse hook
- Suite S (14 groups / 38 assertions) — migration dry-run + apply + collision + orphan folds
- Full plugin suite: 383 PASS / 0 FAIL

## Test plan
- [ ] `bash plugins/saas-startup-team/tests/run-tests.sh` — full suite passes
- [ ] Dry-run on a fresh project's `.startup/handoffs/` — sensible sections
- [ ] `--apply` on a project with mixed content — filesystem matches the plan; INDEX.md regenerated
- [ ] Hook touch-test: Write a non-conforming name in a live session and verify the block message is actionable

## Design + plan
- Spec: `plugins/saas-startup-team/docs/superpowers/specs/2026-04-24-handoff-naming-enforcement-design.md`
- Plan: `plugins/saas-startup-team/docs/superpowers/plans/2026-04-24-handoff-naming-enforcement.md`