### PR TITLE
fix(tribunal-review): v0.2.2 — retry OpenCode reviewers on timeout + raise cap to 420s

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "tribunal-review",
       "description": "Multi-provider code review with Codex, Gemini, OpenCode (GLM + DeepSeek), and Opus arbitration",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": {
         "name": "Andre Paat"
       },

--- a/plugins/tribunal-review/.claude-plugin/plugin.json
+++ b/plugins/tribunal-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tribunal-review",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Multi-provider code review with Codex, Gemini, OpenCode (GLM + DeepSeek), and Opus arbitration",
   "author": {
     "name": "Andre Paat"

--- a/plugins/tribunal-review/README.md
+++ b/plugins/tribunal-review/README.md
@@ -8,7 +8,7 @@ Multi-provider code review plugin for Claude Code. Runs four reviewers in parall
 - [Google Gemini CLI](https://github.com/google-gemini/gemini-cli)
 - [OpenCode CLI](https://opencode.ai) with an [OpenCode Go](https://opencode.ai/go) subscription (provides the `opencode-go/glm-5.1` and `opencode-go/deepseek-v4-pro` models)
 - `jq` (used to parse and validate reviewer JSON output)
-- `timeout` (GNU coreutils; on macOS install coreutils for `gtimeout` or it will fall back to an error-JSON for that reviewer) — caps each reviewer at 5 minutes
+- `timeout` (GNU coreutils; on macOS install coreutils for `gtimeout` or it will fall back to an error-JSON for that reviewer) — caps each reviewer at 7 minutes; the two OpenCode reviewers retry once if they hit the cap (transient OpenCode Go latency spikes)
 - Valid API keys / auth configured for each CLI
 
 Each reviewer degrades gracefully: if a CLI is missing or a model fails, that reviewer emits an error object and the arbiter proceeds with the remaining reviewers.

--- a/plugins/tribunal-review/agents/codex-reviewer.md
+++ b/plugins/tribunal-review/agents/codex-reviewer.md
@@ -94,7 +94,7 @@ cat > "$TMPDIR/codex-review-schema.json" << 'SCHEMA'
 }
 SCHEMA
 
-timeout -k 10 300 codex exec - \
+timeout -k 10 420 codex exec - \
   --output-schema "$TMPDIR/codex-review-schema.json" \
   -o "$TMPDIR/codex-review-output.json" \
   --sandbox read-only \

--- a/plugins/tribunal-review/agents/gemini-reviewer.md
+++ b/plugins/tribunal-review/agents/gemini-reviewer.md
@@ -34,7 +34,7 @@ if [ -z "$DIFF" ]; then
   exit 0
 fi
 
-printf '%s\n' "$DIFF" | timeout -k 10 300 gemini --model gemini-3-pro-preview -p "You are a senior code reviewer performing a thorough security-focused review.
+printf '%s\n' "$DIFF" | timeout -k 10 420 gemini --model gemini-3-pro-preview -p "You are a senior code reviewer performing a thorough security-focused review.
 
 ANALYZE THIS DIFF FOR:
 1. Security vulnerabilities - injection, XSS, CSRF, auth issues, secrets exposure

--- a/plugins/tribunal-review/skills/tribunal-loop/SKILL.md
+++ b/plugins/tribunal-review/skills/tribunal-loop/SKILL.md
@@ -104,7 +104,7 @@ cat > "$TMPDIR/codex-review-schema.json" << 'SCHEMA'
 }
 SCHEMA
 
-timeout -k 10 300 codex exec - \
+timeout -k 10 420 codex exec - \
   --output-schema "$TMPDIR/codex-review-schema.json" \
   -o "$TMPDIR/codex-review-output.json" \
   --sandbox read-only \
@@ -169,7 +169,7 @@ if [ -z "$DIFF" ]; then
   exit 0
 fi
 
-printf '%s\n' "$DIFF" | timeout -k 10 300 gemini --model gemini-3-pro-preview -p "You are a senior code reviewer performing a thorough security-focused review.
+printf '%s\n' "$DIFF" | timeout -k 10 420 gemini --model gemini-3-pro-preview -p "You are a senior code reviewer performing a thorough security-focused review.
 
 ANALYZE THIS DIFF FOR:
 1. Security vulnerabilities - injection, XSS, CSRF, auth issues, secrets exposure
@@ -294,9 +294,13 @@ $([ "$DIFF_TRUNCATED" = true ] && echo "NOTE: Diff was truncated to 200KB. Revie
 THE DIFF:
 $DIFF"
 
-timeout -k 10 300 opencode run --agent plan -m opencode-go/glm-5.1 --variant high --format default --pure "$PROMPT" \
-  >"$TMPDIR/glm-raw.txt" 2>"$TMPDIR/glm-stderr.txt"
-OC_EXIT=$?
+# Retry once on timeout (exit 124) — OpenCode Go latency can transiently spike past the cap
+for attempt in 1 2; do
+  timeout -k 10 420 opencode run --agent plan -m opencode-go/glm-5.1 --variant high --format default --pure "$PROMPT" \
+    >"$TMPDIR/glm-raw.txt" 2>"$TMPDIR/glm-stderr.txt"
+  OC_EXIT=$?
+  [ "$OC_EXIT" -ne 124 ] && break
+done
 
 if [ $OC_EXIT -eq 0 ] && [ -s "$TMPDIR/glm-raw.txt" ]; then
   # Extract between sentinels; fall back to first-{ .. last-} slice
@@ -386,9 +390,13 @@ $([ "$DIFF_TRUNCATED" = true ] && echo "NOTE: Diff was truncated to 200KB. Revie
 THE DIFF:
 $DIFF"
 
-timeout -k 10 300 opencode run --agent plan -m opencode-go/deepseek-v4-pro --variant high --format default --pure "$PROMPT" \
-  >"$TMPDIR/deepseek-raw.txt" 2>"$TMPDIR/deepseek-stderr.txt"
-OC_EXIT=$?
+# Retry once on timeout (exit 124) — OpenCode Go latency can transiently spike past the cap
+for attempt in 1 2; do
+  timeout -k 10 420 opencode run --agent plan -m opencode-go/deepseek-v4-pro --variant high --format default --pure "$PROMPT" \
+    >"$TMPDIR/deepseek-raw.txt" 2>"$TMPDIR/deepseek-stderr.txt"
+  OC_EXIT=$?
+  [ "$OC_EXIT" -ne 124 ] && break
+done
 
 if [ $OC_EXIT -eq 0 ] && [ -s "$TMPDIR/deepseek-raw.txt" ]; then
   JSON=$(sed -n '/===TRIBUNAL_JSON_BEGIN===/,/===TRIBUNAL_JSON_END===/p' "$TMPDIR/deepseek-raw.txt" \


### PR DESCRIPTION
## Summary
Hardens the two OpenCode Go reviewers against the failure seen in the first real-world run.

**Diagnosis** (reproduced in the `est-biz-aruannik-dev` container as user `dev`): the GLM/DeepSeek timeouts were **not** auth, config, concurrency, or a hang. On the real 9.2 KB diff with `--variant high`, GLM completes in ~127s and DeepSeek in ~47s — both well under the cap. At run time the OpenCode Go service was **transiently slow**, pushing the already-minutes-long `--variant high` calls past the 300s cap, so both reviewers hit `timeout` (exit 124). The timeout + graceful degradation worked; the gap was **no retry** and thin headroom.

(Separately: Gemini failed because its **API key is expired** in that container — a credential the user renews; no code change.)

## Changes
- **Retry once on exit 124** for the GLM and DeepSeek reviewer blocks (transient-latency recovery). Retry logic unit-tested for all three paths (succeed-first, retry-then-succeed, give-up-after-two).
- **Raise the per-reviewer cap 300s → 420s** across all four reviewers (+ the standalone agent stubs) for more headroom under high-effort reasoning.
- **Kept `--variant high`** — review quality is good (GLM caught a real crash path + a test-coverage gap in the test run).
- Version `0.2.1 → 0.2.2` in both manifests; README timeout note updated.

## Test Plan
- [x] `bash -n` passes on all four reviewer blocks (retry loops valid)
- [x] Retry loop semantics unit-tested (attempts=1 on success, =2 then exit 0 on retry-success, =2 exit 124 on double-timeout)
- [x] No `300` cap left; 4× `420` in SKILL.md; versions synced at 0.2.2
- [x] Live re-run in container: GLM ~127s / DeepSeek ~47s on the real diff, both succeed and emit valid sentinel-wrapped JSON
- [ ] Confirm recovery on a real timeout spike (only observable when OpenCode Go is degraded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)