### PR TITLE
fix(tribunal-review): v0.2.3 — raise reviewer cap to 600s for long reasoning generation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "tribunal-review",
       "description": "Multi-provider code review with Codex, Gemini, OpenCode (GLM + DeepSeek), and Opus arbitration",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "author": {
         "name": "Andre Paat"
       },

--- a/plugins/tribunal-review/.claude-plugin/plugin.json
+++ b/plugins/tribunal-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tribunal-review",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Multi-provider code review with Codex, Gemini, OpenCode (GLM + DeepSeek), and Opus arbitration",
   "author": {
     "name": "Andre Paat"

--- a/plugins/tribunal-review/README.md
+++ b/plugins/tribunal-review/README.md
@@ -8,7 +8,7 @@ Multi-provider code review plugin for Claude Code. Runs four reviewers in parall
 - [Google Gemini CLI](https://github.com/google-gemini/gemini-cli)
 - [OpenCode CLI](https://opencode.ai) with an [OpenCode Go](https://opencode.ai/go) subscription (provides the `opencode-go/glm-5.1` and `opencode-go/deepseek-v4-pro` models)
 - `jq` (used to parse and validate reviewer JSON output)
-- `timeout` (GNU coreutils; on macOS install coreutils for `gtimeout` or it will fall back to an error-JSON for that reviewer) — caps each reviewer at 7 minutes; the two OpenCode reviewers retry once if they hit the cap (transient OpenCode Go latency spikes)
+- `timeout` (GNU coreutils; on macOS install coreutils for `gtimeout` or it will fall back to an error-JSON for that reviewer) — caps each reviewer at 10 minutes; the two OpenCode reviewers retry once if they hit the cap (the GLM/DeepSeek reasoning models stream long, high-variance chains-of-thought via `opencode --agent plan`)
 - Valid API keys / auth configured for each CLI
 
 Each reviewer degrades gracefully: if a CLI is missing or a model fails, that reviewer emits an error object and the arbiter proceeds with the remaining reviewers.

--- a/plugins/tribunal-review/agents/codex-reviewer.md
+++ b/plugins/tribunal-review/agents/codex-reviewer.md
@@ -94,7 +94,7 @@ cat > "$TMPDIR/codex-review-schema.json" << 'SCHEMA'
 }
 SCHEMA
 
-timeout -k 10 420 codex exec - \
+timeout -k 10 600 codex exec - \
   --output-schema "$TMPDIR/codex-review-schema.json" \
   -o "$TMPDIR/codex-review-output.json" \
   --sandbox read-only \

--- a/plugins/tribunal-review/agents/gemini-reviewer.md
+++ b/plugins/tribunal-review/agents/gemini-reviewer.md
@@ -34,7 +34,7 @@ if [ -z "$DIFF" ]; then
   exit 0
 fi
 
-printf '%s\n' "$DIFF" | timeout -k 10 420 gemini --model gemini-3-pro-preview -p "You are a senior code reviewer performing a thorough security-focused review.
+printf '%s\n' "$DIFF" | timeout -k 10 600 gemini --model gemini-3-pro-preview -p "You are a senior code reviewer performing a thorough security-focused review.
 
 ANALYZE THIS DIFF FOR:
 1. Security vulnerabilities - injection, XSS, CSRF, auth issues, secrets exposure

--- a/plugins/tribunal-review/skills/tribunal-loop/SKILL.md
+++ b/plugins/tribunal-review/skills/tribunal-loop/SKILL.md
@@ -104,7 +104,7 @@ cat > "$TMPDIR/codex-review-schema.json" << 'SCHEMA'
 }
 SCHEMA
 
-timeout -k 10 420 codex exec - \
+timeout -k 10 600 codex exec - \
   --output-schema "$TMPDIR/codex-review-schema.json" \
   -o "$TMPDIR/codex-review-output.json" \
   --sandbox read-only \
@@ -169,7 +169,7 @@ if [ -z "$DIFF" ]; then
   exit 0
 fi
 
-printf '%s\n' "$DIFF" | timeout -k 10 420 gemini --model gemini-3-pro-preview -p "You are a senior code reviewer performing a thorough security-focused review.
+printf '%s\n' "$DIFF" | timeout -k 10 600 gemini --model gemini-3-pro-preview -p "You are a senior code reviewer performing a thorough security-focused review.
 
 ANALYZE THIS DIFF FOR:
 1. Security vulnerabilities - injection, XSS, CSRF, auth issues, secrets exposure
@@ -296,7 +296,7 @@ $DIFF"
 
 # Retry once on timeout (exit 124) — OpenCode Go latency can transiently spike past the cap
 for attempt in 1 2; do
-  timeout -k 10 420 opencode run --agent plan -m opencode-go/glm-5.1 --variant high --format default --pure "$PROMPT" \
+  timeout -k 10 600 opencode run --agent plan -m opencode-go/glm-5.1 --variant high --format default --pure "$PROMPT" \
     >"$TMPDIR/glm-raw.txt" 2>"$TMPDIR/glm-stderr.txt"
   OC_EXIT=$?
   [ "$OC_EXIT" -ne 124 ] && break
@@ -392,7 +392,7 @@ $DIFF"
 
 # Retry once on timeout (exit 124) — OpenCode Go latency can transiently spike past the cap
 for attempt in 1 2; do
-  timeout -k 10 420 opencode run --agent plan -m opencode-go/deepseek-v4-pro --variant high --format default --pure "$PROMPT" \
+  timeout -k 10 600 opencode run --agent plan -m opencode-go/deepseek-v4-pro --variant high --format default --pure "$PROMPT" \
     >"$TMPDIR/deepseek-raw.txt" 2>"$TMPDIR/deepseek-stderr.txt"
   OC_EXIT=$?
   [ "$OC_EXIT" -ne 124 ] && break


### PR DESCRIPTION
## Summary
Raises the per-reviewer `timeout` cap **420s → 600s** (all four reviewers) and keeps the retry-on-timeout on the two OpenCode blocks. `--variant high` is unchanged.

## Why (debug-logged root cause)
A `--print-logs --log-level DEBUG` capture of a real run in the `est-biz-aruannik-dev` container proved the timeouts are **long model generation, not a stall**:
- `opencode run --agent plan` runs a **multi-turn agent loop**; the first `plan` turn alone streamed **~2m11s** (8,296 token-delta events).
- The GLM/DeepSeek **reasoning models** produce long, **high-variance** chains-of-thought — typically 100–180s, with a heavy tail that occasionally exceeds the cap.
- **Ruled out:** OpenCode servers (HTTP 200 in 0.12s over IPv4), network/IPv6 (no fetches/stalls in logs), concurrency (parallel runs fine), CPU/mem (container idle). Dropping `--variant high` did **not** reliably help (within run-to-run variance).

600s gives the reasoning headroom while the retry still covers genuine transient blips. Graceful degradation (Codex + Gemini carry the verdict) remains the backstop.

## Test Plan
- [x] `bash -n` passes on all four reviewer blocks; retry loops intact
- [x] All caps now 600s (no 420/300 left); versions synced at 0.2.3
- [ ] Operational note: a 600s attempt **+ retry** can reach ~20 min for one reviewer. The run only benefits fully if Claude Code's Bash-tool timeout in the container allows it — set `BASH_MAX_TIMEOUT_MS` high enough there if the tool cuts the block off before the internal cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)